### PR TITLE
docs: 新增三篇Vue Transition组件相关博客文章

### DIFF
--- a/content/posts/front_end/vue/CSS搞不定的动画？JavaScript钩子配合GSAP让你为所欲为.md
+++ b/content/posts/front_end/vue/CSS搞不定的动画？JavaScript钩子配合GSAP让你为所欲为.md
@@ -1,0 +1,936 @@
+---
+url: /posts/c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4/
+title: CSS搞不定的动画？JavaScript钩子配合GSAP让你为所欲为
+date: 2026-05-31T12:00:00+08:00
+lastmod: 2026-05-31T12:00:00+08:00
+author: cmdragon
+cover: https://api2.cmdragon.cn/upload/cmder/images/2026年5月31日 20_38_54.png
+
+summary: Vue 3 Transition组件提供了8个JavaScript钩子事件，让你可以在动画的不同阶段执行JS代码。本文详解每个钩子的触发时机、:css="false"的用法、以及如何配合GSAP实现CSS做不到的复杂动画效果。
+
+categories:
+  - vue
+
+tags:
+  - 基础入门
+  - Transition
+  - JavaScript钩子
+  - GSAP
+  - 动画库
+  - :css="false"
+  - 复杂动画
+---
+
+<img src="https://api2.cmdragon.cn/upload/cmder/images/2026年5月31日 20_38_54.png" title="cover.png" alt="cmdragon_cn.png"/>
+
+<img src="https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg" title="cmdragon_cn.png" alt="cmdragon_cn.png"/>
+
+扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`
+
+[发现1000+提升效率与开发的AI工具和实用程序](https://tools.cmdragon.cn/zh/apps?category=ai_chat)：https://tools.cmdragon.cn/zh/apps?category=ai_chat
+
+## 一、8个JavaScript钩子，每个都能干啥？
+
+Vue 3的Transition组件不光能用CSS类名做动画，它还给你准备了8个JavaScript钩子事件。说白了，就是让你在动画的每个关键节点都能插一手，用JS代码来控制动画的行为。CSS transition和animation能做的事毕竟有限，碰到那种需要物理弹簧效果、路径动画、或者要根据数据动态计算动画参数的场景，CSS就有点力不从心了。这时候JS钩子就派上大用场了。
+
+这8个钩子分成两组——进入阶段4个，离开阶段4个，咱们一个一个来看。
+
+### 进入阶段的4个钩子
+
+**@before-enter(el)**：元素插入DOM之前触发。这个时候元素还没出现在页面上，你可以在这里设置元素的初始状态，比如把透明度设为0、位置偏移到屏幕外面之类的。参数`el`就是即将进入的DOM元素。
+
+**@enter(el, done)**：元素插入DOM之后触发。这是执行进入动画的主战场。你在这里写动画逻辑，动画结束之后必须调用`done()`回调，告诉Vue"我这边动画播完了，你可以进行下一步了"。如果你不调用`done`，Vue就会一直等着，动画卡在那不动弹。参数`el`是DOM元素，`done`是完成回调函数。
+
+**@after-enter(el)**：进入动画完全结束后触发。可以在这里做一些收尾工作，比如清理临时样式、触发其他组件的更新、发个事件通知父组件之类的。
+
+**@enter-cancelled(el)**：进入动画被取消时触发。啥时候会被取消呢？比如元素正在执行进入动画的过程中，你突然又让元素离开了，那进入动画就会被取消，这个钩子就会触发。可以在这里做清理工作。
+
+### 离开阶段的4个钩子
+
+**@before-leave(el)**：元素离开动画开始之前触发。可以在这里记录元素当前的位置、尺寸等信息，或者设置离开动画的初始状态。
+
+**@leave(el, done)**：元素离开动画开始时触发。跟`enter`一样，这是执行离开动画的核心钩子。动画结束之后必须调用`done()`，否则Vue不知道动画啥时候结束，元素就一直卡在那。参数`el`是DOM元素，`done`是完成回调。
+
+**@after-leave(el)**：离开动画完全结束后触发。元素已经从DOM中移除了，可以在这里做最终的清理工作。
+
+**@leave-cancelled(el)**：离开动画被取消时触发。这种情况比较少见，一般出现在`v-show`切换的时候——元素正在执行离开动画，突然又要显示了，那离开动画就会被取消。
+
+来看一下这8个钩子的触发时序：
+
+```mermaid
+flowchart TD
+    A[元素状态变化] --> B{显示还是隐藏?}
+
+    B -->|显示 v-if=true| C[@before-enter]
+    C --> D[元素插入DOM]
+    D --> E["@enter（执行进入动画）"]
+    E --> F["调用 done()"]
+    F --> G[@after-enter]
+
+    B -->|隐藏 v-if=false| H[@before-leave]
+    H --> I["@leave（执行离开动画）"]
+    I --> J["调用 done()"]
+    J --> K[元素从DOM移除]
+    K --> L[@after-leave]
+
+    E -.->|动画被中断| M[@enter-cancelled]
+    I -.->|动画被中断| N[@leave-cancelled]
+
+    style C fill:#4CAF50,color:#fff
+    style E fill:#2196F3,color:#fff
+    style G fill:#4CAF50,color:#fff
+    style M fill:#FF9800,color:#fff
+    style H fill:#f44336,color:#fff
+    style I fill:#2196F3,color:#fff
+    style L fill:#f44336,color:#fff
+    style N fill:#FF9800,color:#fff
+```
+
+下面是一个展示所有8个钩子基本用法的代码示例：
+
+```vue
+<template>
+  <button @click="show = !show">切换显示</button>
+
+  <Transition
+    @before-enter="onBeforeEnter"
+    @enter="onEnter"
+    @after-enter="onAfterEnter"
+    @enter-cancelled="onEnterCancelled"
+    @before-leave="onBeforeLeave"
+    @leave="onLeave"
+    @after-leave="onAfterLeave"
+    @leave-cancelled="onLeaveCancelled"
+  >
+    <div v-if="show" class="box">我是个会动的盒子</div>
+  </Transition>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+const show = ref(true);
+
+// 进入阶段：元素还没插入DOM，设置初始状态
+function onBeforeEnter(el) {
+  el.style.opacity = 0;
+  el.style.transform = "translateY(-30px)";
+}
+
+// 进入阶段：元素已插入DOM，执行进入动画
+function onEnter(el, done) {
+  // 这里用原生的Web Animation API做动画
+  const animation = el.animate(
+    [
+      { opacity: 0, transform: "translateY(-30px)" },
+      { opacity: 1, transform: "translateY(0)" },
+    ],
+    {
+      duration: 500,
+      easing: "ease-out",
+    },
+  );
+  // 动画结束后必须调用done，告诉Vue动画播完了
+  animation.onfinish = () => {
+    done();
+  };
+}
+
+// 进入阶段：动画播完了
+function onAfterEnter(el) {
+  console.log("进入动画结束");
+}
+
+// 进入阶段：动画被取消了（比如还没播完就又切走了）
+function onEnterCancelled(el) {
+  console.log("进入动画被取消");
+}
+
+// 离开阶段：动画开始前，记录当前状态
+function onBeforeLeave(el) {
+  el.style.opacity = 1;
+}
+
+// 离开阶段：执行离开动画
+function onLeave(el, done) {
+  const animation = el.animate(
+    [
+      { opacity: 1, transform: "translateY(0)" },
+      { opacity: 0, transform: "translateY(30px)" },
+    ],
+    {
+      duration: 500,
+      easing: "ease-in",
+    },
+  );
+  // 同样必须调用done
+  animation.onfinish = () => {
+    done();
+  };
+}
+
+// 离开阶段：动画播完了，元素已从DOM移除
+function onAfterLeave(el) {
+  console.log("离开动画结束，元素已移除");
+}
+
+// 离开阶段：离开动画被取消（v-show场景下较常见）
+function onLeaveCancelled(el) {
+  console.log("离开动画被取消");
+}
+</script>
+
+<style scoped>
+.box {
+  width: 200px;
+  height: 100px;
+  background: #42b883;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  margin-top: 20px;
+}
+</style>
+```
+
+有个特别重要的事情得强调一下：`enter`和`leave`这两个钩子里的`done`参数，你**必须**调用它！不调用的话Vue就不知道动画啥时候结束，后续的`after-enter`、`after-leave`这些钩子也不会触发，元素可能就卡在半中间的状态。这就好比你跟朋友说"等我一下"，但从来不告诉他"我好了"，他就一直傻等着。
+
+## 二、:css="false"——告诉Vue别管CSS了
+
+默认情况下，Vue的Transition组件是个"双面手"——它同时检测CSS类名和JavaScript钩子。也就是说，即使你写了JS钩子，Vue还是会去检测CSS的`v-enter-active`、`v-leave-active`这些类名，看看有没有CSS transition或animation定义。这就像你请了两个厨师同时做一道菜，虽然也能做出来，但多少有点浪费资源。
+
+当你只用JavaScript钩子来做动画的时候，就可以加一个`:css="false"`，明确告诉Vue："别去检测CSS类名了，我只用JS来控制动画。"
+
+```vue
+<Transition :css="false" @enter="onEnter" @leave="onLeave">
+  <div v-if="show">我只用JS做动画</div>
+</Transition>
+```
+
+加了`:css="false"`之后，会有这么几个变化：
+
+1. Vue不再自动添加和移除CSS类名（`v-enter-from`、`v-enter-active`这些统统不管了）
+2. Vue不再通过检测CSS的`transition-duration`和`animation-duration`来判断动画时长
+3. 动画的结束完全依赖你在`enter`和`leave`钩子中调用`done()`
+4. 性能更好，因为Vue省去了检测CSS规则的开销
+
+来看一个对比示例，让你更直观地感受区别：
+
+```vue
+<template>
+  <div>
+    <button @click="show1 = !show1">不加 :css="false"</button>
+    <button @click="show2 = !show2">加了 :css="false"</button>
+
+    <!-- 不加 :css="false"：Vue同时检测CSS和JS -->
+    <Transition @enter="onEnter1" @leave="onLeave1">
+      <div v-if="show1" class="box">方式一</div>
+    </Transition>
+
+    <!-- 加了 :css="false"：Vue只看JS钩子 -->
+    <Transition :css="false" @enter="onEnter2" @leave="onLeave2">
+      <div v-if="show2" class="box">方式二</div>
+    </Transition>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+const show1 = ref(true);
+const show2 = ref(true);
+
+// 方式一：没加 :css="false"，Vue还会去检测CSS类名
+// 如果CSS里恰好有同名的transition规则，可能会跟JS动画打架
+function onEnter1(el, done) {
+  el.animate([{ opacity: 0 }, { opacity: 1 }], { duration: 400 }).onfinish =
+    done;
+}
+
+function onLeave1(el, done) {
+  el.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 400 }).onfinish =
+    done;
+}
+
+// 方式二：加了 :css="false"，Vue完全不管CSS，只靠JS
+// 不会有CSS规则干扰，动画行为更可控
+function onEnter2(el, done) {
+  el.animate([{ opacity: 0 }, { opacity: 1 }], { duration: 400 }).onfinish =
+    done;
+}
+
+function onLeave2(el, done) {
+  el.animate([{ opacity: 1 }, { opacity: 0 }], { duration: 400 }).onfinish =
+    done;
+}
+</script>
+```
+
+那什么时候该加`:css="false"`呢？很简单——**当你只用JavaScript来控制动画，不需要CSS类名参与的时候，就加上它**。这样做既能让代码意图更清晰，又能避免CSS规则意外干扰JS动画，还能稍微提升一点性能。一举三得，何乐而不为呢？
+
+## 三、GSAP——动画界的扛把子
+
+原生Web Animation API虽然能用，但说实话功能还是比较有限。要做那种丝滑的弹性动画、物理弹簧效果、复杂的时间轴编排，还是得上专业的动画库。而GSAP（GreenSock Animation Platform）就是动画库里的"扛把子"，用过的都说香。
+
+### GSAP是什么
+
+GSAP是GreenSock公司开发的JavaScript动画平台，它最大的特点就是——**快**。不是一般的快，是那种60fps丝滑流畅的快。它内部做了大量性能优化，比jQuery的animate快20倍，比CSS动画在某些场景下也更流畅。而且API设计得特别简洁，几行代码就能写出让人眼前一亮的动画效果。
+
+### 安装GSAP
+
+在你的Vue 3项目中，一行命令就能装上：
+
+```bash
+npm install gsap
+```
+
+截至2026年5月，GSAP的最新稳定版本是3.12.x系列。安装完之后就可以直接在组件里用了。
+
+### GSAP的基本用法
+
+GSAP最核心的API就两个：`gsap.to()`和`gsap.from()`。
+
+`gsap.to()`——让元素从当前状态动画到目标状态：
+
+```javascript
+// 让元素在1秒内透明度变为1，向右移动200px
+gsap.to(el, {
+  opacity: 1,
+  x: 200,
+  duration: 1,
+});
+```
+
+`gsap.from()`——让元素从指定状态动画到当前状态：
+
+```javascript
+// 让元素从透明+上方30px的位置动画到当前位置
+gsap.from(el, {
+  opacity: 0,
+  y: -30,
+  duration: 0.5,
+});
+```
+
+还有个`gsap.fromTo()`——同时指定起始和结束状态：
+
+```javascript
+gsap.fromTo(
+  el,
+  { opacity: 0, y: -30 }, // 起始状态
+  { opacity: 1, y: 0, duration: 0.5 }, // 结束状态
+);
+```
+
+### 在Transition钩子中使用GSAP
+
+把GSAP和Vue Transition的JS钩子结合起来，那叫一个天作之合。来看一个弹性动画的例子：
+
+```vue
+<template>
+  <button @click="show = !show">弹性动画</button>
+
+  <Transition :css="false" @enter="onEnter" @leave="onLeave">
+    <div v-if="show" class="ball">🏀</div>
+  </Transition>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import gsap from "gsap";
+
+const show = ref(true);
+
+function onEnter(el, done) {
+  // 设置初始状态：透明 + 缩小
+  gsap.set(el, {
+    opacity: 0,
+    scale: 0.3,
+  });
+
+  // 弹性进入动画
+  gsap.to(el, {
+    opacity: 1,
+    scale: 1,
+    duration: 0.8,
+    // ease参数控制缓动函数，elastic.out是弹性效果
+    ease: "elastic.out(1, 0.5)",
+    // onComplete是GSAP的完成回调，在这里调用done通知Vue
+    onComplete: done,
+  });
+}
+
+function onLeave(el, done) {
+  gsap.to(el, {
+    opacity: 0,
+    scale: 0.3,
+    duration: 0.4,
+    ease: "back.in(2)",
+    onComplete: done,
+  });
+}
+</script>
+
+<style scoped>
+.ball {
+  width: 80px;
+  height: 80px;
+  font-size: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 20px;
+}
+</style>
+```
+
+注意看上面的代码，GSAP的`onComplete`回调就是用来替代手动调用`done()`的。当GSAP动画播完之后，它会自动调用`onComplete`，我们在里面调用`done()`通知Vue动画结束。这样就不需要自己手动追踪动画状态了。
+
+### 用GSAP做CSS做不到的事
+
+CSS动画虽然方便，但有些效果它就是搞不定。举几个GSAP能做但CSS做不好的例子：
+
+**物理弹簧效果**：CSS的`cubic-bezier`只能定义固定的贝塞尔曲线，而GSAP的`elastic`、`bounce`、`back`这些缓动函数能模拟真实的物理弹簧和弹跳效果，看起来自然多了。
+
+**路径动画**：GSAP的MotionPath插件可以让元素沿着SVG路径运动，CSS要实现这个得费老大劲了。
+
+**时间轴控制**：GSAP的`gsap.timeline()`可以编排多个动画的先后顺序、重叠关系，甚至可以整体暂停、倒放、加速。CSS的`animation-delay`虽然也能做简单的时序控制，但灵活度差远了。
+
+来看一个时间轴编排的例子：
+
+```vue
+<template>
+  <button @click="show = !show">时间轴动画</button>
+
+  <Transition :css="false" @enter="onEnter" @leave="onLeave">
+    <div v-if="show" class="card">
+      <div class="card-header">标题</div>
+      <div class="card-body">内容区域</div>
+      <div class="card-footer">底部</div>
+    </div>
+  </Transition>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import gsap from "gsap";
+
+const show = ref(true);
+
+function onEnter(el, done) {
+  // 创建时间轴，让子元素依次动画进入
+  const tl = gsap.timeline({ onComplete: done });
+
+  tl.from(el, {
+    opacity: 0,
+    y: 30,
+    duration: 0.3,
+    ease: "power2.out",
+  })
+    // 标题先出来
+    .from(
+      el.querySelector(".card-header"),
+      {
+        opacity: 0,
+        x: -20,
+        duration: 0.3,
+        ease: "power2.out",
+      },
+      "-=0.1",
+    )
+    // 内容区域接着出来，跟标题有0.1秒的重叠
+    .from(
+      el.querySelector(".card-body"),
+      {
+        opacity: 0,
+        y: 15,
+        duration: 0.3,
+        ease: "power2.out",
+      },
+      "-=0.1",
+    )
+    // 底部最后出来
+    .from(
+      el.querySelector(".card-footer"),
+      {
+        opacity: 0,
+        duration: 0.2,
+        ease: "power2.out",
+      },
+      "-=0.1",
+    );
+}
+
+function onLeave(el, done) {
+  gsap.to(el, {
+    opacity: 0,
+    scale: 0.95,
+    y: 20,
+    duration: 0.3,
+    ease: "power2.in",
+    onComplete: done,
+  });
+}
+</script>
+
+<style scoped>
+.card {
+  width: 300px;
+  margin-top: 20px;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  background: white;
+}
+
+.card-header {
+  padding: 16px 20px;
+  background: #42b883;
+  color: white;
+  font-weight: bold;
+  font-size: 18px;
+}
+
+.card-body {
+  padding: 20px;
+  color: #333;
+  line-height: 1.6;
+}
+
+.card-footer {
+  padding: 12px 20px;
+  background: #f5f5f5;
+  color: #999;
+  font-size: 14px;
+}
+</style>
+```
+
+这种子元素依次入场的效果，用CSS也能勉强做（给每个子元素设不同的`animation-delay`），但代码又臭又长，而且不好维护。用GSAP的时间轴，几行代码就搞定了，还能精确控制动画之间的重叠关系。
+
+## 四、用GSAP做一个完整的弹窗动画
+
+学了一堆理论，咱们来整一个实际项目中最常见的场景——模态框弹窗动画。一个好的弹窗动画应该是什么样的？弹出来的时候要有弹性，让人感觉"弹"出来的；关掉的时候要干脆利落，别拖泥带水。而且弹窗的背景遮罩也要有渐入渐出的效果。
+
+先来看一下整个弹窗动画的流程：
+
+```mermaid
+flowchart TD
+    A[用户点击打开按钮] --> B[show = true]
+    B --> C["@before-enter：设置弹窗初始状态\nopacity=0, scale=0.5, y=50"]
+    C --> D["@enter：GSAP执行进入动画\n遮罩渐入 + 弹窗弹性放大"]
+    D --> E["GSAP onComplete → done()"]
+    E --> F["@after-enter：弹窗完全显示"]
+
+    G[用户点击关闭按钮] --> H[show = false]
+    H --> I["@before-leave：记录当前状态"]
+    I --> J["@leave：GSAP执行离开动画\n弹窗缩小 + 遮罩渐出"]
+    J --> K["GSAP onComplete → done()"]
+    K --> L["@after-leave：弹窗完全关闭\n元素从DOM移除"]
+
+    style C fill:#4CAF50,color:#fff
+    style D fill:#2196F3,color:#fff
+    style F fill:#4CAF50,color:#fff
+    style I fill:#f44336,color:#fff
+    style J fill:#2196F3,color:#fff
+    style L fill:#f44336,color:#fff
+```
+
+下面是完整的代码实现：
+
+```vue
+<template>
+  <button class="open-btn" @click="showModal = true">打开弹窗</button>
+
+  <Transition
+    :css="false"
+    @before-enter="onBeforeEnter"
+    @enter="onEnter"
+    @before-leave="onBeforeLeave"
+    @leave="onLeave"
+  >
+    <div v-if="showModal" class="modal-overlay" @click.self="showModal = false">
+      <div class="modal-content">
+        <h2>欢迎来到弹窗世界</h2>
+        <p>这是一个用GSAP驱动的弹性弹窗动画，CSS可做不出来这种弹簧效果哦。</p>
+        <div class="modal-actions">
+          <button class="btn-confirm" @click="showModal = false">确认</button>
+          <button class="btn-cancel" @click="showModal = false">取消</button>
+        </div>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import gsap from "gsap";
+
+const showModal = ref(false);
+
+// 进入前：设置弹窗和遮罩的初始状态
+function onBeforeEnter(el) {
+  // 遮罩层初始完全透明
+  gsap.set(el, {
+    opacity: 0,
+  });
+  // 弹窗内容初始：缩小 + 位置偏下
+  const content = el.querySelector(".modal-content");
+  gsap.set(content, {
+    opacity: 0,
+    scale: 0.5,
+    y: 50,
+  });
+}
+
+// 进入动画：遮罩渐入 + 弹窗弹性放大
+function onEnter(el, done) {
+  const content = el.querySelector(".modal-content");
+
+  // 创建时间轴，编排遮罩和弹窗的动画
+  const tl = gsap.timeline({ onComplete: done });
+
+  // 遮罩层先渐入
+  tl.to(el, {
+    opacity: 1,
+    duration: 0.3,
+    ease: "power2.out",
+  })
+    // 弹窗内容弹性放大，跟遮罩有0.1秒重叠
+    .to(
+      content,
+      {
+        opacity: 1,
+        scale: 1,
+        y: 0,
+        duration: 0.6,
+        // elastic.out模拟弹簧效果，(1, 0.5)控制弹性和阻尼
+        ease: "elastic.out(1, 0.5)",
+      },
+      "-=0.1",
+    );
+}
+
+// 离开前：不需要特别处理，当前状态就是离开的起始状态
+function onBeforeLeave(el) {
+  // 可以在这里做一些记录，比如当前弹窗的位置
+  // 这个例子中不需要额外操作
+}
+
+// 离开动画：弹窗缩小 + 遮罩渐出
+function onLeave(el, done) {
+  const content = el.querySelector(".modal-content");
+
+  const tl = gsap.timeline({ onComplete: done });
+
+  // 弹窗先缩小消失
+  tl.to(content, {
+    opacity: 0,
+    scale: 0.8,
+    y: 30,
+    duration: 0.25,
+    ease: "power2.in",
+  })
+    // 遮罩接着渐出
+    .to(
+      el,
+      {
+        opacity: 0,
+        duration: 0.2,
+        ease: "power2.in",
+      },
+      "-=0.1",
+    );
+}
+</script>
+
+<style scoped>
+.open-btn {
+  padding: 12px 24px;
+  background: #42b883;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 16px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.open-btn:hover {
+  background: #369970;
+}
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 16px;
+  padding: 32px;
+  width: 420px;
+  max-width: 90vw;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.modal-content h2 {
+  margin: 0 0 16px;
+  color: #333;
+  font-size: 22px;
+}
+
+.modal-content p {
+  margin: 0 0 24px;
+  color: #666;
+  line-height: 1.6;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.btn-confirm {
+  padding: 10px 24px;
+  background: #42b883;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.btn-cancel {
+  padding: 10px 24px;
+  background: #f5f5f5;
+  color: #666;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.btn-confirm:hover {
+  background: #369970;
+}
+
+.btn-cancel:hover {
+  background: #e8e8e8;
+}
+</style>
+```
+
+这段代码里有几个值得注意的地方：
+
+第一，`onBeforeEnter`里用`gsap.set()`来设置初始状态。`gsap.set()`是立即设置属性值，不带动画，相当于"瞬移"到指定状态。这比手动操作`el.style`要方便得多，因为GSAP会自动处理浏览器兼容性问题。
+
+第二，`onEnter`里用`gsap.timeline()`编排了两个动画——遮罩渐入和弹窗弹性放大。`'-=0.1'`这个参数表示第二个动画提前0.1秒开始，让遮罩和弹窗的动画有一小段重叠，看起来更连贯。
+
+第三，`elastic.out(1, 0.5)`这个缓动函数是整个动画的灵魂。第一个参数1控制弹性强度（越大弹得越厉害），第二个参数0.5控制阻尼（越大弹得越快停下来）。你可以调整这两个参数来获得不同的弹簧感觉。
+
+第四，离开动画用的是`power2.in`缓动函数，这是一个加速效果，让弹窗关掉的时候有一种"被吸走"的感觉，跟进入时的弹性效果形成对比。
+
+## 课后 Quiz
+
+**问题1：在Transition的`enter`钩子中，如果忘记调用`done()`回调，会发生什么？**
+
+答案解析：如果忘记调用`done()`，Vue会认为进入动画一直没有结束，后续的`after-enter`钩子永远不会触发。更严重的是，如果此时用户又触发了离开操作，Vue可能会进入一个混乱的状态，因为前一个动画还没"结案"呢。所以`done()`就像是给Vue的一个"动画完成确认单"，不签收的话Vue就一直等着。如果你加了`:css="false"`，那`done()`就更加关键了，因为Vue完全依赖它来判断动画何时结束。
+
+**问题2：什么时候应该给Transition加上`:css="false"`？不加会有什么影响？**
+
+答案解析：当你只用JavaScript钩子来控制动画、完全不依赖CSS类名的时候，就应该加上`:css="false"`。不加的话，Vue还是会去检测CSS的`v-enter-active`、`v-leave-active`等类名，看看有没有定义`transition`或`animation`属性。这个检测过程虽然开销不大，但完全没必要。更麻烦的是，如果你的CSS里恰好有同名的类名规则（比如全局样式或者UI框架的样式），可能会跟你的JS动画产生冲突，导致动画行为不符合预期。加上`:css="false"`就能彻底避免这些问题。
+
+**问题3：GSAP的`gsap.timeline()`相比单独调用多个`gsap.to()`有什么优势？**
+
+答案解析：`gsap.timeline()`最大的优势是能精确编排多个动画的时序关系。单独调用`gsap.to()`的话，多个动画是同时开始的（除非你手动计算delay），而且很难控制动画之间的重叠和衔接。timeline提供了一套简洁的API来控制动画的先后顺序、重叠时间，还能整体暂停、恢复、倒放、调整播放速度。另外，timeline的`onComplete`只需要写一次，所有子动画都完成后才触发，而单独的`gsap.to()`你得自己追踪每个动画的完成状态，代码会复杂得多。
+
+## 常见报错解决方案
+
+### 报错1：动画卡住不动，元素停在半透明状态
+
+**原因分析**：这是最常见的问题，几乎都是因为在`enter`或`leave`钩子中忘记调用`done()`回调。Vue不知道动画什么时候结束，就一直在等，元素就卡在动画中间的状态了。
+
+**解决方案**：检查你的`enter`和`leave`钩子，确保在动画结束的时候调用了`done()`。如果用的是GSAP，就在`onComplete`里调用；如果用的是Web Animation API，就在`animation.onfinish`里调用。另外，如果你加了`:css="false"`，那`done()`就更加不可或缺了，因为Vue没有任何其他方式知道动画何时结束。
+
+```javascript
+// 错误写法：忘记调用done
+function onEnter(el, done) {
+  gsap.to(el, { opacity: 1, duration: 0.5 });
+  // done()去哪了？？？
+}
+
+// 正确写法：在onComplete中调用done
+function onEnter(el, done) {
+  gsap.to(el, {
+    opacity: 1,
+    duration: 0.5,
+    onComplete: done,
+  });
+}
+```
+
+### 报错2：GSAP动画和CSS动画互相打架，效果很诡异
+
+**原因分析**：没有加`:css="false"`，Vue还在自动添加CSS类名。如果你的CSS里定义了`v-enter-active`或`v-leave-active`的`transition`属性，那CSS transition和GSAP动画就会同时作用在同一个元素上，互相干扰。比如GSAP在控制`opacity`，CSS transition也在控制`opacity`，两个动画叠加在一起，效果就乱套了。
+
+**解决方案**：如果你只用JS钩子做动画，一定要加上`:css="false"`。如果你确实需要同时使用CSS和JS动画，那就确保它们控制的是不同的CSS属性，避免冲突。
+
+```vue
+<!-- 只用JS做动画时，务必加上 :css="false" -->
+<Transition :css="false" @enter="onEnter" @leave="onLeave">
+  <div v-if="show">内容</div>
+</Transition>
+```
+
+### 报错3：快速切换时动画闪烁或元素消失
+
+**原因分析**：快速切换显示/隐藏时，前一个动画还没播完，新的动画就开始了。这时候`enter-cancelled`和`leave-cancelled`钩子会被触发，但如果你没有在取消时清理正在进行的GSAP动画，旧的动画实例还在运行，就会跟新动画冲突。
+
+**解决方案**：在`enter-cancelled`和`leave-cancelled`钩子中，使用GSAP的`kill()`方法来终止正在进行的动画。或者更好的做法是，在每次开始新动画之前，先用`gsap.killTweensOf(el)`清理元素上所有正在进行的GSAP动画。
+
+```javascript
+function onEnter(el, done) {
+  // 先杀掉元素上可能残留的旧动画
+  gsap.killTweensOf(el);
+
+  gsap.fromTo(
+    el,
+    { opacity: 0, scale: 0.5 },
+    {
+      opacity: 1,
+      scale: 1,
+      duration: 0.5,
+      ease: "elastic.out(1, 0.5)",
+      onComplete: done,
+    },
+  );
+}
+
+function onEnterCancelled(el) {
+  // 动画被取消时，杀掉正在进行的GSAP动画
+  gsap.killTweensOf(el);
+}
+
+function onLeave(el, done) {
+  gsap.killTweensOf(el);
+
+  gsap.to(el, {
+    opacity: 0,
+    scale: 0.8,
+    duration: 0.3,
+    onComplete: done,
+  });
+}
+
+function onLeaveCancelled(el) {
+  gsap.killTweensOf(el);
+}
+```
+
+参考链接：https://vuejs.org/guide/built-ins/transition.html
+
+余下文章内容请点击跳转至 个人博客页面 或者 扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`，阅读完整的文章：[CSS搞不定的动画？JavaScript钩子配合GSAP让你为所欲为](https://blog.cmdragon.cn/posts/c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4/)
+
+<details>
+<summary>往期文章归档</summary>
+
+- [Vue 3 静态与动态 Props 如何传递？TypeScript 类型约束有何必要？](https://blog.cmdragon.cn/posts/94ab48753b64780ca3ab7a7115ae8522/)
+- [Vue 3中组件局部注册的优势与实现方式如何？](https://blog.cmdragon.cn/posts/dbf576e744870f6de26fd8a2e03e47da/)
+- [如何在Vue3中优化生命周期钩子性能并规避常见陷阱？](https://blog.cmdragon.cn/posts/12d98b3b9ccd6c19a1b169d720ac5c80/)
+- [Vue 3 Composition API生命周期钩子：如何实现从基础理解到高阶复用？](https://blog.cmdragon.cn/posts/8884e2b70287fcb263c57648eeb27419/)
+- [Vue 3生命周期钩子实战指南：如何正确选择onMounted、onUpdated与onUnmounted的应用场景？](https://blog.cmdragon.cn/posts/883c6dbc50ae4183770a4462e0b8ae4d/)
+- [Vue 3中生命周期钩子与响应式系统如何实现协同工作？](https://blog.cmdragon.cn/posts/70dad360ffa9dce14d0d69611b8cb019/)
+- [Vue 3组件生命周期钩子的执行顺序与使用场景是什么？](https://blog.cmdragon.cn/posts/db44294a78dc9f666f67b053f6c83567/)
+- [Vue组件全局注册与局部注册如何抉择？](https://blog.cmdragon.cn/posts/43ead630ea17da65d99ad2eb8188e472/)
+- [Vue3组件化开发中，Props与Emits如何实现数据流转与事件协作？](https://blog.cmdragon.cn/posts/8cff7d2df113da66ea7be560c4d1d22a/)
+- [Vue 3模板引用如何与其他特性协同实现复杂交互？](https://blog.cmdragon.cn/posts/331bf75d114ab09116eadfcdca602b58/)
+- [Vue 3 v-for中模板引用如何实现高效管理与动态控制？](https://blog.cmdragon.cn/posts/cb380897ddc3578b180ecf8843c774c1/)
+- [Vue 3的defineExpose：如何突破script setup组件默认封装，实现精准的父子通讯？](https://blog.cmdragon.cn/posts/202ae0f4acde7128e0e31baf63732fb5/)
+- [Vue 3模板引用的生命周期时机如何把握？常见陷阱该如何避免？](https://blog.cmdragon.cn/posts/7d2a0f6555ecbe92afd7d2491c427463/)
+- [Vue 3模板引用如何实现父组件与子组件的高效交互？](https://blog.cmdragon.cn/posts/3fb7bdd84128b7efaaa1c979e1f28dee/)
+- [Vue中为何需要模板引用？又如何高效实现DOM与组件实例的直接访问？](https://blog.cmdragon.cn/posts/23f3464ba16c7054b4783cded50c04c6/)
+
+</details>
+
+<details>
+<summary>免费好用的热门在线工具</summary>
+
+- [多直播聚合器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/multi-live-aggregator)
+- [Proto文件生成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/proto-file-generator)
+- [图片转粒子 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/image-to-particles)
+- [视频下载器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/video-downloader)
+- [文件格式转换器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/file-converter)
+- [M3U8在线播放器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/m3u8-player)
+- [快图设计 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/quick-image-design)
+- [高级文字转图片转换器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/text-to-image-advanced)
+- [RAID 计算器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/raid-calculator)
+- [在线PS - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/photoshop-online)
+- [Mermaid 在线编辑器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/mermaid-live-editor)
+- [数学求解计算器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/math-solver-calculator)
+- [智能提词器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/smart-teleprompter)
+- [魔法简历 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/magic-resume)
+- [Image Puzzle Tool - 图片拼图工具 | By cmdragon](https://tools.cmdragon.cn/zh/apps/image-puzzle-tool)
+- [字幕下载工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/subtitle-downloader)
+- [歌词生成工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/lyrics-generator)
+- [网盘资源聚合搜索 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/cloud-drive-search)
+- [ASCII字符画生成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/ascii-art-generator)
+- [JSON Web Tokens 工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/jwt-tool)
+- [Bcrypt 密码工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/bcrypt-tool)
+- [GIF 合成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/gif-composer)
+- [GIF 分解器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/gif-decomposer)
+- [文本隐写术 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/text-steganography)
+- [CMDragon 在线工具 - 高级AI工具箱与开发者套件 | 免费好用的在线工具](https://tools.cmdragon.cn/zh)
+- [应用商店 - 发现1000+提升效率与开发的AI工具和实用程序 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps?category=trending)
+- [CMDragon 更新日志 - 最新更新、功能与改进 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/changelog)
+- [支持我们 - 成为赞助者 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/sponsor)
+- [AI文本生成图像 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/text-to-image-ai)
+- [临时邮箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/temp-email)
+- [二维码解析器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/qrcode-parser)
+- [文本转思维导图 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/text-to-mindmap)
+- [正则表达式可视化工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/regex-visualizer)
+- [文件隐写工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/steganography-tool)
+- [IPTV 频道探索器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/iptv-explorer)
+- [快传 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/snapdrop)
+- [随机抽奖工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/lucky-draw)
+- [动漫场景查找器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/anime-scene-finder)
+- [时间工具箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/time-toolkit)
+- [网速测试 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/speed-test)
+- [AI 智能抠图工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/background-remover)
+- [背景替换工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/background-replacer)
+- [艺术二维码生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/artistic-qrcode)
+- [Open Graph 元标签生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/open-graph-generator)
+- [图像对比工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/image-comparison)
+- [图片压缩专业版 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/image-compressor)
+- [密码生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/password-generator)
+- [SVG优化器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/svg-optimizer)
+- [调色板生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/color-palette)
+- [在线节拍器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/online-metronome)
+- [IP归属地查询 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/ip-geolocation)
+- [CSS网格布局生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/css-grid-layout)
+- [邮箱验证工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/email-validator)
+- [书法练习字帖 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/calligraphy-practice)
+- [金融计算器套件 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/finance-calculator-suite)
+- [中国亲戚关系计算器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/chinese-kinship-calculator)
+- [Protocol Buffer 工具箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/protobuf-toolkit)
+- [IP归属地查询 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/ip-geolocation)
+- [图片无损放大 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/image-upscaler)
+- [文本比较工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/text-compare)
+- [IP批量查询工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/ip-batch-lookup)
+- [域名查询工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/domain-finder)
+- [DNS工具箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/dns-toolkit)
+- [网站图标生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/favicon-generator)
+- [XML Sitemap](https://tools.cmdragon.cn/sitemap_index.xml)
+
+</details>

--- a/content/posts/front_end/vue/Vue的Transition组件到底能干啥？6个CSS类名帮你搞定进出动画.md
+++ b/content/posts/front_end/vue/Vue的Transition组件到底能干啥？6个CSS类名帮你搞定进出动画.md
@@ -1,0 +1,827 @@
+---
+url: /posts/a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2/
+title: Vue的Transition组件到底能干啥？6个CSS类名帮你搞定进出动画
+date: 2026-05-31T10:00:00+08:00
+lastmod: 2026-05-31T10:00:00+08:00
+author: cmdragon
+cover: https://api2.cmdragon.cn/upload/cmder/images/2026年5月31日 20_33_03.png
+
+summary: Vue 3的Transition组件是内置的动画利器，本文从Transition组件的基本概念讲起，搞清楚它什么时候触发、6个CSS过渡类名分别干啥、命名过渡怎么用、CSS transition和CSS animation两种方式的区别。
+
+categories:
+  - vue
+
+tags:
+  - 基础入门
+  - Transition
+  - 过渡动画
+  - CSS类名
+  - 命名过渡
+  - 进出动画
+  - Vue内置组件
+---
+
+<img src="https://api2.cmdragon.cn/upload/cmder/images/2026年5月31日 20_33_03.png" title="cover.png" alt="cmdragon_cn.png"/>
+
+<img src="https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg" title="cmdragon_cn.png" alt="cmdragon_cn.png"/>
+
+扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`
+
+[发现1000+提升效率与开发的AI工具和实用程序](https://tools.cmdragon.cn/zh/apps?category=ai_chat)：https://tools.cmdragon.cn/zh/apps?category=ai_chat
+
+## 一、Transition组件是啥？为啥需要它？
+
+你有没有遇到过这种情况——页面上一个弹窗，点一下"打开"它啪地就蹦出来了，点一下"关闭"它嗖地就没了。用户看着一愣一愣的，感觉就像看PPT切幻灯片一样生硬。这体验，说实话，不太行。
+
+Vue 3给咱们准备了一个内置组件，就叫`<Transition>`，专门干一件事：给元素或组件的"出场"和"退场"加上动画效果。有了它，弹窗可以淡入淡出，侧边栏可以滑进滑出，标签页切换可以有个过渡——总之，页面就不那么"硬切"了。
+
+打个比方，没有Transition的时候，元素的出现和消失就像一扇门突然被踹开又突然被摔上；有了Transition，这扇门就装了自动开关，缓缓打开、轻轻关上，看着就舒服多了。
+
+基本用法特别简单，把你想要加动画的元素用`<Transition>`包起来就行：
+
+```vue
+<template>
+  <!-- 用Transition包裹需要动画的元素 -->
+  <Transition>
+    <!-- v-if控制元素的显示和隐藏 -->
+    <div v-if="show" class="box">你好，我是有动画的元素</div>
+  </Transition>
+  <!-- 按钮切换显示状态 -->
+  <button @click="show = !show">切换显示</button>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+// 控制元素是否显示
+const show = ref(true);
+</script>
+
+<style>
+/* 进入和离开的过渡效果 */
+.v-enter-active,
+.v-leave-active {
+  transition: opacity 0.5s ease;
+}
+
+/* 进入的起始状态和离开的结束状态：透明 */
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
+}
+</style>
+```
+
+就这么几行代码，元素在显示和隐藏的时候就会有0.5秒的淡入淡出效果。是不是比硬切好看多了？
+
+有一点要注意，`<Transition>`只能包裹一个直接子元素。如果你往里面塞两个兄弟元素，Vue会直接报错。如果你有多个元素需要同时做动画，得用`<TransitionGroup>`，那是另一个组件了，咱们以后再聊。
+
+另外，`<Transition>`本身不会渲染任何DOM元素，它就是一个逻辑容器，告诉Vue"嘿，我里面的元素在进出的时候要加动画"。最终渲染出来的DOM里，你是看不到`<Transition>`这个标签的。
+
+## 二、Transition什么时候触发？四种情况
+
+光知道Transition是干啥的还不够，你还得搞清楚它啥时候才会触发。不是随便什么时候都会触发动画的，只有以下四种情况，Transition才会"醒来干活"：
+
+### 1. v-if 条件渲染
+
+这是最常见的触发方式。当`v-if`的值从`false`变成`true`，元素"进入"，触发进入动画；从`true`变成`false`，元素"离开"，触发离开动画。
+
+```vue
+<template>
+  <Transition>
+    <p v-if="show">我是v-if控制的元素</p>
+  </Transition>
+  <button @click="show = !show">切换</button>
+</template>
+
+<script setup>
+import { ref } from "vue";
+const show = ref(true);
+</script>
+```
+
+### 2. v-show 条件显示
+
+`v-show`也能触发Transition。跟`v-if`的区别是，`v-if`是真正地销毁和创建DOM元素，而`v-show`只是切换`display`属性。但不管哪种方式，Transition都能感知到变化并触发动画。
+
+```vue
+<template>
+  <Transition>
+    <p v-show="show">我是v-show控制的元素</p>
+  </Transition>
+  <button @click="show = !show">切换</button>
+</template>
+
+<script setup>
+import { ref } from "vue";
+const show = ref(true);
+</script>
+```
+
+### 3. 动态组件切换
+
+用`<component :is="...">`切换动态组件的时候，Transition也能派上用场。组件A切到组件B，A做离开动画，B做进入动画。
+
+```vue
+<template>
+  <Transition mode="out-in">
+    <!-- 动态组件，根据currentComponent的值切换 -->
+    <component :is="currentComponent"></component>
+  </Transition>
+  <button @click="toggle">切换组件</button>
+</template>
+
+<script setup>
+import { ref, shallowRef } from "vue";
+import CompA from "./CompA.vue";
+import CompB from "./CompB.vue";
+
+// 当前显示的组件
+const currentComponent = shallowRef(CompA);
+
+function toggle() {
+  // 在CompA和CompB之间切换
+  currentComponent.value = currentComponent.value === CompA ? CompB : CompA;
+}
+</script>
+```
+
+### 4. 改变特殊的 key 属性
+
+这个可能很多人不知道。当你给Transition里的元素绑定一个动态的`key`，key值变化的时候，Vue会认为这是一个全新的元素，旧元素做离开动画，新元素做进入动画。
+
+```vue
+<template>
+  <Transition>
+    <!-- key变化时触发过渡 -->
+    <div :key="count">{{ count }}</div>
+  </Transition>
+  <button @click="count++">加1</button>
+</template>
+
+<script setup>
+import { ref } from "vue";
+const count = ref(0);
+</script>
+```
+
+这招在做数字翻牌动画、计数器动画的时候特别好用。
+
+下面用一张流程图把四种触发机制串起来，看一眼就明白了：
+
+```mermaid
+flowchart TD
+    A[Transition包裹的元素] --> B{状态发生变化？}
+    B -->|v-if 值变化| C[触发进入/离开动画]
+    B -->|v-show 值变化| D[触发进入/离开动画]
+    B -->|动态组件切换| E[触发进入/离开动画]
+    B -->|key 值变化| F[触发进入/离开动画]
+    B -->|无变化| G[不触发动画]
+    C --> H[Vue添加对应CSS类名]
+    D --> H
+    E --> H
+    F --> H
+    H --> I[浏览器执行CSS过渡/动画]
+    I --> J[动画结束，清理类名]
+```
+
+说白了，Transition的触发逻辑就是：**它里面的元素在DOM中"来了"或"走了"，它就会给元素加上对应的CSS类名，然后浏览器根据这些类名里的样式来播放动画。** 你不需要手动去添加或删除类名，Vue全帮你干了。
+
+## 三、6个CSS过渡类名，一个一个掰扯
+
+这是本文的重头戏。Transition组件之所以能工作，核心就是靠这6个CSS类名。Vue会在不同的时机自动给元素添加和移除这些类名，你只要在CSS里定义好这些类名的样式，动画就出来了。
+
+先把6个类名列出来，咱们一个一个说：
+
+| 类名             | 什么时候出现       | 干啥的                                |
+| ---------------- | ------------------ | ------------------------------------- |
+| `v-enter-from`   | 进入动画的第一帧   | 定义元素进入时的起始状态              |
+| `v-enter-active` | 进入动画的整个过程 | 定义进入时的transition属性或animation |
+| `v-enter-to`     | 进入动画的最后一帧 | 定义元素进入后的最终状态              |
+| `v-leave-from`   | 离开动画的第一帧   | 定义元素离开时的起始状态              |
+| `v-leave-active` | 离开动画的整个过程 | 定义离开时的transition属性或animation |
+| `v-leave-to`     | 离开动画的最后一帧 | 定义元素离开后的最终状态              |
+
+### 进入的三个类名
+
+想象一个演员上台表演。`v-enter-from`就是演员在幕布后面的状态——还没上台，观众看不到（比如`opacity: 0`）。`v-enter-active`就是演员从幕布后面走到舞台中间的整个过程——这个过程中你需要告诉浏览器"用0.5秒的时间，ease的节奏，慢慢走过来"（比如`transition: opacity 0.5s ease`）。`v-enter-to`就是演员站到舞台中间了——观众清清楚楚看到他（比如`opacity: 1`）。
+
+### 离开的三个类名
+
+同理，`v-leave-from`就是演员还在舞台上的状态——观众能看到他（比如`opacity: 1`）。`v-leave-active`就是演员从舞台中间走回幕布后面的过程——同样需要告诉浏览器过渡参数。`v-leave-to`就是演员已经退到幕布后面了——观众看不到了（比如`opacity: 0`）。
+
+用流程图来看更直观：
+
+```mermaid
+timeline
+    title Transition CSS类名时间线
+    section 进入阶段
+        第1帧 : v-enter-from 添加 : 元素插入DOM : 起始状态（如opacity:0）
+        整个过程 : v-enter-active 添加 : 定义transition属性 : 控制过渡节奏
+        最后一帧 : v-enter-to 添加 : 最终状态（如opacity:1）
+        动画结束 : 三个类名全部移除 : 元素保持最终状态
+    section 离开阶段
+        第1帧 : v-leave-from 添加 : 起始状态（如opacity:1）
+        整个过程 : v-leave-active 添加 : 定义transition属性 : 控制过渡节奏
+        最后一帧 : v-leave-to 添加 : 最终状态（如opacity:0）
+        动画结束 : 三个类名全部移除 : 元素从DOM移除
+```
+
+### 为啥enter-active和leave-active要写transition属性？
+
+这个问题很多人搞不明白。答案其实很简单：`v-enter-from`和`v-enter-to`只是定义了"从什么状态变到什么状态"，但浏览器怎么知道要花多长时间、用什么节奏来变？这就得靠`v-enter-active`里的`transition`属性来告诉浏览器了。
+
+如果你只写了`v-enter-from { opacity: 0 }`和`v-enter-to { opacity: 1 }`，没写`v-enter-active { transition: opacity 0.5s }`，那元素会瞬间从透明变成不透明——跟没加动画一样。因为浏览器不知道要过渡，就直接跳到最终状态了。
+
+来一个完整的淡入淡出示例：
+
+```vue
+<template>
+  <div class="demo-container">
+    <!-- Transition包裹需要动画的元素 -->
+    <Transition>
+      <div v-if="show" class="message-box">这是一条会淡入淡出的消息</div>
+    </Transition>
+    <button @click="show = !show">{{ show ? "隐藏" : "显示" }}</button>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+// 控制消息的显示和隐藏
+const show = ref(true);
+</script>
+
+<style scoped>
+.demo-container {
+  text-align: center;
+  padding: 20px;
+}
+
+.message-box {
+  padding: 20px;
+  background: #42b883;
+  color: white;
+  border-radius: 8px;
+  margin-bottom: 16px;
+}
+
+/* 进入的起始状态：完全透明 */
+.v-enter-from {
+  opacity: 0;
+}
+
+/* 进入过程中：定义过渡属性，0.5秒，ease缓动 */
+.v-enter-active {
+  transition: opacity 0.5s ease;
+}
+
+/* 进入的结束状态：完全不透明 */
+.v-enter-to {
+  opacity: 1;
+}
+
+/* 离开的起始状态：完全不透明 */
+.v-leave-from {
+  opacity: 1;
+}
+
+/* 离开过程中：定义过渡属性，0.5秒，ease缓动 */
+.v-leave-active {
+  transition: opacity 0.5s ease;
+}
+
+/* 离开的结束状态：完全透明 */
+.v-leave-to {
+  opacity: 0;
+}
+</style>
+```
+
+这里有个小细节：`v-enter-to`和`v-leave-from`其实可以不写，因为元素正常状态就是`opacity: 1`，Vue会自动用元素的默认样式作为这两个状态。但写上也没错，有时候为了代码可读性，写上反而更清晰。
+
+再来看一个滑动+淡入的例子，让你感受一下6个类名搭配使用的威力：
+
+```vue
+<template>
+  <div class="slide-demo">
+    <Transition>
+      <div v-if="show" class="slide-box">我会从左边滑进来，再滑出去</div>
+    </Transition>
+    <button @click="show = !show">切换</button>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+const show = ref(true);
+</script>
+
+<style scoped>
+.slide-demo {
+  padding: 20px;
+  overflow: hidden;
+}
+
+.slide-box {
+  padding: 20px;
+  background: #35495e;
+  color: white;
+  border-radius: 8px;
+  margin-bottom: 16px;
+}
+
+/* 进入起始：透明 + 向左偏移30px */
+.v-enter-from {
+  opacity: 0;
+  transform: translateX(-30px);
+}
+
+/* 进入过程：同时过渡opacity和transform */
+.v-enter-active {
+  transition: all 0.5s ease;
+}
+
+/* 进入结束：不透明 + 原位 */
+.v-enter-to {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+/* 离开起始：不透明 + 原位 */
+.v-leave-from {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+/* 离开过程：同时过渡opacity和transform */
+.v-leave-active {
+  transition: all 0.5s ease;
+}
+
+/* 离开结束：透明 + 向右偏移30px */
+.v-leave-to {
+  opacity: 0;
+  transform: translateX(30px);
+}
+</style>
+```
+
+看到了吧？`transform`和`opacity`可以同时过渡，`transition: all 0.5s ease`就搞定了。元素进来的时候从左边滑入，出去的时候往右边滑出，非常有方向感。
+
+## 四、命名过渡——给Transition取个名字
+
+前面咱们用的类名都是`v-`开头的，比如`v-enter-from`、`v-leave-active`。但你想啊，一个页面上如果有好几个Transition，都用`v-`开头的类名，那CSS不就打架了？你给A元素写的过渡样式，B元素也用上了，这哪行啊。
+
+所以Vue给Transition提供了一个`name`属性，让你给它取个名字。取了名字之后，类名前缀就从`v-`变成你取的名字加横杠。
+
+比如`<Transition name="fade">`，那6个类名就变成了：
+
+- `fade-enter-from`
+- `fade-enter-active`
+- `fade-enter-to`
+- `fade-leave-from`
+- `fade-leave-active`
+- `fade-leave-to`
+
+这样一来，每个Transition的样式就互不干扰了。来看个实际例子，页面上同时有淡入淡出和滑动两种动画：
+
+```vue
+<template>
+  <div class="named-demo">
+    <!-- 淡入淡出的Transition，name设为fade -->
+    <Transition name="fade">
+      <div v-if="showFade" class="box fade-box">我是淡入淡出的</div>
+    </Transition>
+    <button @click="showFade = !showFade">淡入淡出切换</button>
+
+    <!-- 滑动的Transition，name设为slide -->
+    <Transition name="slide">
+      <div v-if="showSlide" class="box slide-box">我是滑进滑出的</div>
+    </Transition>
+    <button @click="showSlide = !showSlide">滑动切换</button>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+// 分别控制两种动画的显示状态
+const showFade = ref(true);
+const showSlide = ref(true);
+</script>
+
+<style scoped>
+.named-demo {
+  padding: 20px;
+}
+
+.box {
+  padding: 16px;
+  border-radius: 8px;
+  margin-bottom: 12px;
+  color: white;
+}
+
+.fade-box {
+  background: #42b883;
+}
+
+.slide-box {
+  background: #35495e;
+}
+
+/* fade命名过渡的样式 */
+.fade-enter-from {
+  opacity: 0;
+}
+.fade-enter-active {
+  transition: opacity 0.4s ease;
+}
+.fade-enter-to {
+  opacity: 1;
+}
+.fade-leave-from {
+  opacity: 1;
+}
+.fade-leave-active {
+  transition: opacity 0.4s ease;
+}
+.fade-leave-to {
+  opacity: 0;
+}
+
+/* slide命名过渡的样式 */
+.slide-enter-from {
+  opacity: 0;
+  transform: translateY(-20px);
+}
+.slide-enter-active {
+  transition: all 0.4s ease;
+}
+.slide-enter-to {
+  opacity: 1;
+  transform: translateY(0);
+}
+.slide-leave-from {
+  opacity: 1;
+  transform: translateY(0);
+}
+.slide-leave-active {
+  transition: all 0.4s ease;
+}
+.slide-leave-to {
+  opacity: 0;
+  transform: translateY(20px);
+}
+</style>
+```
+
+你看，`fade-`开头的类名管淡入淡出，`slide-`开头的类名管滑动，互不干扰，清清爽爽。
+
+如果你不给Transition设name，那默认就是`v-`前缀。所以前面那些例子里的`v-enter-from`之类的，其实都是"匿名过渡"。实际项目中，养成给Transition取名字的习惯，代码可读性和可维护性都会好很多。
+
+还有一点，如果你用了`scoped`样式，那类名必须跟Transition的name对应上，不然样式不生效。这个坑很多人踩过——明明CSS写了，动画就是不出来，排查半天发现是类名前缀没对上。
+
+## 五、CSS transition和CSS animation有啥区别？
+
+到目前为止，咱们用的都是CSS `transition`属性来做过渡。但其实Transition组件还支持另一种方式：CSS `animation`。这两种方式都能实现动画效果，但原理和写法不太一样。
+
+### CSS transition方式
+
+这就是咱们前面一直在用的方式。核心思路是：定义起始状态和结束状态，然后用`transition`属性告诉浏览器"用多长时间、什么节奏来过渡"。
+
+特点：
+
+- 需要触发条件（类名的添加和移除就是触发条件）
+- 只能定义从A状态到B状态的过渡
+- 写法上需要用到`v-enter-from`、`v-enter-to`、`v-leave-from`、`v-leave-to`这四个类名
+
+### CSS animation方式
+
+用`@keyframes`定义关键帧动画，然后在`v-enter-active`和`v-leave-active`里引用这个动画。
+
+特点：
+
+- 动画定义好后可以自动播放，不需要触发
+- 可以定义多个关键帧，实现更复杂的动画
+- 写法上只需要`v-enter-active`和`v-leave-active`两个类名就够了，因为动画本身已经包含了起始和结束状态
+
+来对比一下两种写法：
+
+```vue
+<template>
+  <div class="compare-demo">
+    <h3>transition方式</h3>
+    <Transition name="trans-fade">
+      <div v-if="show1" class="box">transition淡入淡出</div>
+    </Transition>
+    <button @click="show1 = !show1">切换</button>
+
+    <h3>animation方式</h3>
+    <Transition name="anim-bounce">
+      <div v-if="show2" class="box">animation弹跳效果</div>
+    </Transition>
+    <button @click="show2 = !show2">切换</button>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+const show1 = ref(true);
+const show2 = ref(true);
+</script>
+
+<style scoped>
+.compare-demo {
+  padding: 20px;
+}
+
+.box {
+  padding: 16px;
+  background: #42b883;
+  color: white;
+  border-radius: 8px;
+  margin-bottom: 12px;
+}
+
+/* ========== transition方式 ========== */
+/* 需要定义from和to状态，加上active的transition属性 */
+.trans-fade-enter-from {
+  opacity: 0;
+}
+.trans-fade-enter-active {
+  transition: opacity 0.5s ease;
+}
+.trans-fade-enter-to {
+  opacity: 1;
+}
+.trans-fade-leave-from {
+  opacity: 1;
+}
+.trans-fade-leave-active {
+  transition: opacity 0.5s ease;
+}
+.trans-fade-leave-to {
+  opacity: 0;
+}
+
+/* ========== animation方式 ========== */
+/* 定义进入动画的关键帧 */
+@keyframes bounce-in {
+  0% {
+    transform: scale(0.5);
+    opacity: 0;
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+/* 定义离开动画的关键帧 */
+@keyframes bounce-out {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(0.5);
+    opacity: 0;
+  }
+}
+
+/* animation方式只需要写active类名 */
+.anim-bounce-enter-active {
+  animation: bounce-in 0.5s ease;
+}
+.anim-bounce-leave-active {
+  animation: bounce-out 0.5s ease;
+}
+</style>
+```
+
+看到区别了吧？animation方式里，`@keyframes`已经把0%、50%、100%的状态都定义好了，所以不需要再单独写`enter-from`、`enter-to`这些类名。Vue在进入时给元素加上`anim-bounce-enter-active`类，浏览器就会自动播放`bounce-in`动画；离开时加上`anim-bounce-leave-active`类，播放`bounce-out`动画。
+
+那什么时候用transition，什么时候用animation呢？简单来说：
+
+- **简单的A到B的状态变化**（比如淡入淡出、滑动），用transition就够了，代码少，好理解
+- **需要多关键帧、复杂路径的动画**（比如弹跳、摇摆、旋转多圈），用animation更合适，表达能力更强
+
+两种方式也可以混用，比如进入用animation做一个弹跳效果，离开用transition做一个简单的淡出。Transition组件不挑食，只要你写的CSS类名对得上，它都能识别。
+
+## 课后 Quiz
+
+### 问题1：Transition组件的6个CSS类名中，哪个类名是必须写的？为什么？
+
+**答案解析：**
+
+6个类名中没有哪个是"绝对必须"写的，但`v-enter-active`和`v-leave-active`是最关键的。因为这两个类名负责定义`transition`属性（或`animation`属性），告诉浏览器过渡的时长和节奏。如果你只写了`v-enter-from`和`v-enter-to`但没写`v-enter-active`，浏览器不知道要过渡，会直接跳到最终状态，动画效果就没了。
+
+如果用的是CSS animation方式，那只需要`v-enter-active`和`v-leave-active`就够了，因为`@keyframes`里已经包含了起始和结束状态。
+
+### 问题2：`<Transition name="slide">`对应的CSS类名前缀是什么？如果不设name属性呢？
+
+**答案解析：**
+
+设了`name="slide"`之后，6个类名前缀就变成了`slide-`，比如`slide-enter-from`、`slide-leave-active`等。如果不设name属性，默认前缀是`v-`，对应的类名就是`v-enter-from`、`v-leave-active`等。
+
+命名过渡的核心作用就是让同一个页面上多个Transition组件的样式互不干扰。实际开发中，强烈建议给每个Transition都取个有意义的名字。
+
+### 问题3：v-if和v-show都能触发Transition，它们在触发机制上有啥区别？
+
+**答案解析：**
+
+- `v-if`是真正的条件渲染，当值为`false`时，元素会从DOM中移除；值为`true`时，元素会重新创建并插入DOM。所以Transition的进入动画发生在元素插入DOM时，离开动画发生在元素从DOM移除前。
+- `v-show`只是切换CSS的`display`属性，元素始终在DOM中。当`display`从`none`变成其他值时触发进入动画，从其他值变成`none`时触发离开动画。
+
+实际选择时，如果元素切换频繁且需要保留状态，用`v-show`更合适；如果元素很大、切换不频繁，用`v-if`更省性能。两种方式Transition都能正常工作。
+
+## 常见报错解决方案
+
+### 报错1：`<Transition> can only have one child element`
+
+**原因分析：** 你在`<Transition>`里放了多个兄弟元素。Transition组件只允许有一个直接子元素，多了它不知道该给谁加动画。
+
+**解决方案：** 用一个容器元素把多个元素包起来，或者改用`<TransitionGroup>`。
+
+```vue
+<!-- 错误写法 -->
+<Transition>
+  <div>元素1</div>
+  <div>元素2</div>
+</Transition>
+
+<!-- 正确写法1：用容器包裹 -->
+<Transition>
+  <div>
+    <div>元素1</div>
+    <div>元素2</div>
+  </div>
+</Transition>
+
+<!-- 正确写法2：用TransitionGroup -->
+<TransitionGroup>
+  <div>元素1</div>
+  <div>元素2</div>
+</TransitionGroup>
+```
+
+### 报错2：动画完全不生效，元素瞬间出现/消失
+
+**原因分析：** 最常见的原因是CSS类名没写对。比如Transition设了`name="fade"`，但CSS里写的还是`v-enter-from`而不是`fade-enter-from`。或者用了`scoped`样式但类名前缀不匹配。
+
+**解决方案：** 检查CSS类名前缀是否跟Transition的name属性一致。如果没设name，前缀就是`v-`；如果设了`name="fade"`，前缀必须是`fade-`。
+
+```vue
+<!-- 如果name是fade -->
+<Transition name="fade">
+  <div v-if="show">内容</div>
+</Transition>
+
+<!-- CSS类名必须是fade-开头 -->
+<style scoped>
+/* 错误：用了v-前缀 */
+.v-enter-active {
+  transition: opacity 0.5s;
+}
+
+/* 正确：用fade-前缀 */
+.fade-enter-active {
+  transition: opacity 0.5s;
+}
+</style>
+```
+
+另外一个常见原因是忘了写`v-enter-active`或`v-leave-active`里的`transition`属性。没有这个属性，浏览器不会做过渡，元素会直接跳到最终状态。
+
+### 报错3：离开动画还没播完，元素就消失了
+
+**原因分析：** 你可能用了`v-if`，但CSS里的离开过渡时长跟`v-leave-active`里定义的不一致。或者你同时用了JavaScript钩子和CSS过渡，导致冲突。
+
+**解决方案：** 确保离开动画的时长足够。Vue会自动检测CSS过渡的时长来决定什么时候移除DOM元素，但如果你的`transition-duration`设得太短（比如0.1s），动画看起来就像没有一样。
+
+```css
+/* 确保过渡时长合理 */
+.v-leave-active {
+  transition: all 0.5s ease; /* 不要设太短 */
+}
+```
+
+如果你需要更精确地控制时长，可以用`duration`属性：
+
+```vue
+<!-- 显式指定过渡时长为500ms -->
+<Transition :duration="500">
+  <div v-if="show">内容</div>
+</Transition>
+
+<!-- 也可以分别指定进入和离开的时长 -->
+<Transition :duration="{ enter: 500, leave: 300 }">
+  <div v-if="show">内容</div>
+</Transition>
+```
+
+参考链接：https://vuejs.org/guide/built-ins/transition.html
+
+余下文章内容请点击跳转至 个人博客页面 或者 扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`，阅读完整的文章：[Vue的Transition组件到底能干啥？6个CSS类名帮你搞定进出动画](https://blog.cmdragon.cn/posts/a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2/)
+
+<details>
+<summary>往期文章归档</summary>
+
+- [Vue 3 静态与动态 Props 如何传递？TypeScript 类型约束有何必要？](https://blog.cmdragon.cn/posts/94ab48753b64780ca3ab7a7115ae8522/)
+- [Vue 3中组件局部注册的优势与实现方式如何？](https://blog.cmdragon.cn/posts/dbf576e744870f6de26fd8a2e03e47da/)
+- [如何在Vue3中优化生命周期钩子性能并规避常见陷阱？](https://blog.cmdragon.cn/posts/12d98b3b9ccd6c19a1b169d720ac5c80/)
+- [Vue 3 Composition API生命周期钩子：如何实现从基础理解到高阶复用？](https://blog.cmdragon.cn/posts/8884e2b70287fcb263c57648eeb27419/)
+- [Vue 3生命周期钩子实战指南：如何正确选择onMounted、onUpdated与onUnmounted的应用场景？](https://blog.cmdragon.cn/posts/883c6dbc50ae4183770a4462e0b8ae4d/)
+- [Vue 3中生命周期钩子与响应式系统如何实现协同工作？](https://blog.cmdragon.cn/posts/70dad360ffa9dce14d0d69611b8cb019/)
+- [Vue 3组件生命周期钩子的执行顺序与使用场景是什么？](https://blog.cmdragon.cn/posts/db44294a78dc9f666f67b053f6c83567/)
+- [Vue组件全局注册与局部注册如何抉择？](https://blog.cmdragon.cn/posts/43ead630ea17da65d99ad2eb8188e472/)
+- [Vue3组件化开发中，Props与Emits如何实现数据流转与事件协作？](https://blog.cmdragon.cn/posts/8cff7d2df113da66ea7be560c4d1d22a/)
+- [Vue 3模板引用如何与其他特性协同实现复杂交互？](https://blog.cmdragon.cn/posts/331bf75d114ab09116eadfcdca602b58/)
+- [Vue 3 v-for中模板引用如何实现高效管理与动态控制？](https://blog.cmdragon.cn/posts/cb380897ddc3578b180ecf8843c774c1/)
+- [Vue 3的defineExpose：如何突破script setup组件默认封装，实现精准的父子通讯？](https://blog.cmdragon.cn/posts/202ae0f4acde7128e0e31baf63732fb5/)
+- [Vue 3模板引用的生命周期时机如何把握？常见陷阱该如何避免？](https://blog.cmdragon.cn/posts/7d2a0f6555ecbe92afd7d2491c427463/)
+- [Vue 3模板引用如何实现父组件与子组件的高效交互？](https://blog.cmdragon.cn/posts/3fb7bdd84128b7efaaa1c979e1f28dee/)
+- [Vue中为何需要模板引用？又如何高效实现DOM与组件实例的直接访问？](https://blog.cmdragon.cn/posts/23f3464ba16c7054b4783cded50c04c6/)
+
+</details>
+
+<details>
+<summary>免费好用的热门在线工具</summary>
+
+- [多直播聚合器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/multi-live-aggregator)
+- [Proto文件生成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/proto-file-generator)
+- [图片转粒子 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/image-to-particles)
+- [视频下载器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/video-downloader)
+- [文件格式转换器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/file-converter)
+- [M3U8在线播放器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/m3u8-player)
+- [快图设计 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/quick-image-design)
+- [高级文字转图片转换器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/text-to-image-advanced)
+- [RAID 计算器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/raid-calculator)
+- [在线PS - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/photoshop-online)
+- [Mermaid 在线编辑器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/mermaid-live-editor)
+- [数学求解计算器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/math-solver-calculator)
+- [智能提词器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/smart-teleprompter)
+- [魔法简历 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/magic-resume)
+- [Image Puzzle Tool - 图片拼图工具 | By cmdragon](https://tools.cmdragon.cn/zh/apps/image-puzzle-tool)
+- [字幕下载工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/subtitle-downloader)
+- [歌词生成工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/lyrics-generator)
+- [网盘资源聚合搜索 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/cloud-drive-search)
+- [ASCII字符画生成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/ascii-art-generator)
+- [JSON Web Tokens 工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/jwt-tool)
+- [Bcrypt 密码工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/bcrypt-tool)
+- [GIF 合成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/gif-composer)
+- [GIF 分解器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/gif-decomposer)
+- [文本隐写术 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/text-steganography)
+- [CMDragon 在线工具 - 高级AI工具箱与开发者套件 | 免费好用的在线工具](https://tools.cmdragon.cn/zh)
+- [应用商店 - 发现1000+提升效率与开发的AI工具和实用程序 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps?category=trending)
+- [CMDragon 更新日志 - 最新更新、功能与改进 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/changelog)
+- [支持我们 - 成为赞助者 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/sponsor)
+- [AI文本生成图像 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/text-to-image-ai)
+- [临时邮箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/temp-email)
+- [二维码解析器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/qrcode-parser)
+- [文本转思维导图 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/text-to-mindmap)
+- [正则表达式可视化工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/regex-visualizer)
+- [文件隐写工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/steganography-tool)
+- [IPTV 频道探索器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/iptv-explorer)
+- [快传 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/snapdrop)
+- [随机抽奖工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/lucky-draw)
+- [动漫场景查找器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/anime-scene-finder)
+- [时间工具箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/time-toolkit)
+- [网速测试 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/speed-test)
+- [AI 智能抠图工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/background-remover)
+- [背景替换工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/background-replacer)
+- [艺术二维码生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/artistic-qrcode)
+- [Open Graph 元标签生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/open-graph-generator)
+- [图像对比工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/image-comparison)
+- [图片压缩专业版 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/image-compressor)
+- [密码生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/password-generator)
+- [SVG优化器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/svg-optimizer)
+- [调色板生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/color-palette)
+- [在线节拍器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/online-metronome)
+- [IP归属地查询 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/ip-geolocation)
+- [CSS网格布局生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/css-grid-layout)
+- [邮箱验证工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/email-validator)
+- [书法练习字帖 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/calligraphy-practice)
+- [金融计算器套件 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/finance-calculator-suite)
+- [中国亲戚关系计算器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/chinese-kinship-calculator)
+- [Protocol Buffer 工具箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/protobuf-toolkit)
+- [IP归属地查询 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/ip-geolocation)
+- [图片无损放大 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/image-upscaler)
+- [文本比较工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/text-compare)
+- [IP批量查询工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/ip-batch-lookup)
+- [域名查询工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/domain-finder)
+- [DNS工具箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/dns-toolkit)
+- [网站图标生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/favicon-generator)
+- [XML Sitemap](https://tools.cmdragon.cn/sitemap_index.xml)
+
+</details>

--- a/content/posts/front_end/vue/不想写CSS类名？用自定义类名和Animate.css让动画飞起来.md
+++ b/content/posts/front_end/vue/不想写CSS类名？用自定义类名和Animate.css让动画飞起来.md
@@ -1,0 +1,913 @@
+---
+url: /posts/b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3/
+title: 不想写CSS类名？用自定义类名和Animate.css让动画飞起来
+date: 2026-05-31T11:00:00+08:00
+lastmod: 2026-05-31T11:00:00+08:00
+author: cmdragon
+cover: https://api2.cmdragon.cn/upload/cmder/images/2026年5月31日 20_35_19.png
+
+summary: Vue 3 Transition组件支持自定义过渡类名，让你可以直接用Animate.css等第三方动画库的类名。本文讲解6个自定义类名prop、Animate.css集成方法、同时使用transition和animation时type属性的用法。
+
+categories:
+  - vue
+
+tags:
+  - 基础入门
+  - Transition
+  - 自定义类名
+  - Animate.css
+  - type属性
+  - 动画库
+  - CSS动画
+---
+
+<img src="https://api2.cmdragon.cn/upload/cmder/images/2026年5月31日 20_35_19.png" title="cover.png" alt="cmdragon_cn.png"/>
+
+<img src="https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg" title="cmdragon_cn.png" alt="cmdragon_cn.png"/>
+
+扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`
+
+[发现1000+提升效率与开发的AI工具和实用程序](https://tools.cmdragon.cn/zh/apps?category=ai_chat)：https://tools.cmdragon.cn/zh/apps?category=ai_chat
+
+## 一、自定义类名prop——不想用v-开头？随你
+
+Vue 3的`<Transition>`组件默认给你生成6个CSS类名，长这样：`v-enter-from`、`v-enter-active`、`v-enter-to`、`v-leave-from`、`v-leave-active`、`v-leave-to`。如果你给Transition加了`name`属性，比如`name="fade"`，那这些类名就变成`fade-enter-from`这种格式。
+
+但问题来了——你手上有一个现成的CSS动画库，比如Animate.css，人家类名叫`animate__bounceIn`，你总不能把人家源码改了吧？或者你自己团队有一套命名规范，非要用`my-fancy-enter`这种名字，那咋整？
+
+这就轮到**自定义类名prop**出场了。Transition组件给你提供了6个prop，让你直接指定每个阶段用哪个CSS类名，完全绕过默认的命名规则。
+
+### 6个自定义类名prop一览
+
+| prop名               | 对应的默认类名   | 干啥的                                   |
+| -------------------- | ---------------- | ---------------------------------------- |
+| `enter-from-class`   | `v-enter-from`   | 进入动画的起始状态                       |
+| `enter-active-class` | `v-enter-active` | 进入动画的整个过程（定义过渡曲线、时长） |
+| `enter-to-class`     | `v-enter-to`     | 进入动画的结束状态                       |
+| `leave-from-class`   | `v-leave-from`   | 离开动画的起始状态                       |
+| `leave-active-class` | `v-leave-active` | 离开动画的整个过程                       |
+| `leave-to-class`     | `v-leave-to`     | 离开动画的结束状态                       |
+
+打个比方，默认类名就像你去餐厅吃套餐，菜单上写啥你吃啥。自定义类名prop就像你跟厨师说"我不吃套餐，我要单点"，每道菜你自己指定。
+
+### 用自定义类名替换默认类名
+
+来看个最基础的例子，我们用自定义类名prop把默认的`v-`前缀全换掉：
+
+```vue
+<template>
+  <!-- 用自定义类名prop指定每个阶段对应的CSS类名 -->
+  <Transition
+    enter-from-class="my-enter-from"
+    enter-active-class="my-enter-active"
+    enter-to-class="my-enter-to"
+    leave-from-class="my-leave-from"
+    leave-active-class="my-leave-active"
+    leave-to-class="my-leave-to"
+  >
+    <div v-if="show" class="box">我进来了~</div>
+  </Transition>
+
+  <button @click="show = !show">切换显示</button>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+// 控制元素的显示和隐藏
+const show = ref(true);
+</script>
+
+<style>
+/* 进入动画的起始状态：透明且向下偏移30px */
+.my-enter-from {
+  opacity: 0;
+  transform: translateY(30px);
+}
+
+/* 进入动画的过程：0.5秒，使用ease-out曲线 */
+.my-enter-active {
+  transition: all 0.5s ease-out;
+}
+
+/* 进入动画的结束状态：完全不透明，回到原位 */
+.my-enter-to {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* 离开动画的起始状态：完全不透明，在原位 */
+.my-leave-from {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* 离开动画的过程：0.5秒，使用ease-in曲线 */
+.my-leave-active {
+  transition: all 0.5s ease-in;
+}
+
+/* 离开动画的结束状态：透明且向上偏移30px */
+.my-leave-to {
+  opacity: 0;
+  transform: translateY(-30px);
+}
+
+.box {
+  width: 200px;
+  height: 100px;
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  font-size: 18px;
+}
+</style>
+```
+
+你看，这里我们完全没用`v-`开头的默认类名，而是用`my-`前缀的自定义类名。Transition组件通过那6个prop知道该在哪个阶段添加哪个类名，跟默认的行为一模一样，只是名字变了。
+
+你可能会想，这不就是换个名字嘛，有啥用？别急，关键在于——你可以把类名指向**第三方CSS动画库**的类名，这样就不用自己写任何CSS动画了！接下来我们就来看看怎么跟Animate.css配合。
+
+## 二、Animate.css集成——几行代码搞定炫酷动画
+
+### Animate.css是啥
+
+Animate.css是一个跨浏览器的CSS动画库，里面预置了几十种动画效果——弹跳、淡入淡出、翻转、缩放、滑动……你想到的它基本都有。你只需要给元素加上对应的类名，动画就出来了，完全不用自己写`@keyframes`。
+
+它的官网地址是 https://animate.style/ ，你可以去上面挑你喜欢的动画效果。
+
+### 安装和引入
+
+在你的Vue 3项目里，先安装Animate.css：
+
+```bash
+npm install animate.css
+```
+
+然后在入口文件（通常是`main.js`或`main.ts`）里引入它：
+
+```js
+// main.js
+import { createApp } from "vue";
+import App from "./App.vue";
+// 引入Animate.css的样式文件，这样所有动画类名就可用了
+import "animate.css";
+
+createApp(App).mount("#app");
+```
+
+就这么简单，引入之后Animate.css的所有类名就全局可用了。
+
+### 在Transition中使用Animate.css
+
+Animate.css的类名有个统一的前缀`animate__`（注意是双下划线），比如`animate__bounceIn`、`animate__bounceOut`、`animate__fadeInDown`等等。
+
+我们用Transition的自定义类名prop，把这些Animate.css的类名直接填进去就行：
+
+```vue
+<template>
+  <!-- 使用Animate.css的类名作为自定义过渡类名 -->
+  <Transition
+    enter-active-class="animate__animated animate__bounceIn"
+    leave-active-class="animate__animated animate__bounceOut"
+  >
+    <div v-if="show" class="box">弹弹弹，弹走鱼尾纹~</div>
+  </Transition>
+
+  <button @click="show = !show">切换显示</button>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+// 控制元素的显示和隐藏
+const show = ref(true);
+</script>
+
+<style>
+.box {
+  width: 200px;
+  height: 100px;
+  background: linear-gradient(135deg, #f093fb, #f5576c);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  font-size: 18px;
+}
+</style>
+```
+
+注意看，我们只指定了`enter-active-class`和`leave-active-class`，没有指定`enter-from-class`那些。为啥？因为Animate.css的动画是`@keyframes`驱动的，它自己会处理起始帧和结束帧，不需要你额外指定from和to的状态。你只需要告诉Transition"进入的时候用哪个动画、离开的时候用哪个动画"就够了。
+
+另外别忘了，每个Animate.css动画类名前面都要加上`animate__animated`这个基础类，它负责启用动画功能。这就像你开灯得先拉总闸，`animate__animated`就是那个总闸。
+
+### 多种动画效果组合
+
+Animate.css提供了超多动画效果，你可以随意组合进入和离开的动画。下面这个例子展示了不同的动画搭配：
+
+```vue
+<template>
+  <div class="demo-container">
+    <!-- 第一组：bounceIn / bounceOut 弹跳进出 -->
+    <div class="demo-group">
+      <h3>弹跳效果</h3>
+      <Transition
+        enter-active-class="animate__animated animate__bounceIn"
+        leave-active-class="animate__animated animate__bounceOut"
+      >
+        <div v-if="show1" class="box bounce-box">弹跳进出</div>
+      </Transition>
+      <button @click="show1 = !show1">切换弹跳</button>
+    </div>
+
+    <!-- 第二组：fadeInDown / fadeOutUp 从下滑入/向上滑出 -->
+    <div class="demo-group">
+      <h3>滑动淡入淡出</h3>
+      <Transition
+        enter-active-class="animate__animated animate__fadeInDown"
+        leave-active-class="animate__animated animate__fadeOutUp"
+      >
+        <div v-if="show2" class="box fade-box">滑动进出</div>
+      </Transition>
+      <button @click="show2 = !show2">切换滑动</button>
+    </div>
+
+    <!-- 第三组：flipInX / flipOutX X轴翻转 -->
+    <div class="demo-group">
+      <h3>翻转效果</h3>
+      <Transition
+        enter-active-class="animate__animated animate__flipInX"
+        leave-active-class="animate__animated animate__flipOutX"
+      >
+        <div v-if="show3" class="box flip-box">翻转进出</div>
+      </Transition>
+      <button @click="show3 = !show3">切换翻转</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+// 三组独立的显示/隐藏状态
+const show1 = ref(true);
+const show2 = ref(true);
+const show3 = ref(true);
+</script>
+
+<style>
+.demo-container {
+  display: flex;
+  gap: 40px;
+  padding: 20px;
+}
+
+.demo-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.box {
+  width: 160px;
+  height: 80px;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.bounce-box {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+}
+
+.fade-box {
+  background: linear-gradient(135deg, #f093fb, #f5576c);
+}
+
+.flip-box {
+  background: linear-gradient(135deg, #4facfe, #00f2fe);
+}
+
+button {
+  padding: 8px 16px;
+  border: none;
+  border-radius: 4px;
+  background: #333;
+  color: white;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #555;
+}
+</style>
+```
+
+### Animate.css动画时长调整
+
+Animate.css默认动画时长是1秒，你可以通过CSS变量来调整：
+
+```vue
+<template>
+  <!-- 通过style覆盖Animate.css的动画时长变量 -->
+  <Transition
+    enter-active-class="animate__animated animate__bounceIn"
+    leave-active-class="animate__animated animate__bounceOut"
+    :style="{ '--animate-duration': '0.5s' }"
+  >
+    <div v-if="show" class="box">0.5秒弹跳</div>
+  </Transition>
+
+  <button @click="show = !show">切换</button>
+</template>
+
+<script setup>
+import { ref } from "vue";
+const show = ref(true);
+</script>
+
+<style>
+/* 全局覆盖Animate.css的动画时长 */
+:root {
+  --animate-duration: 800ms;
+}
+
+.box {
+  width: 200px;
+  height: 100px;
+  background: linear-gradient(135deg, #a18cd1, #fbc2eb);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+}
+</style>
+```
+
+### Animate.css与Transition配合流程
+
+下面这个流程图把Animate.css和Transition组件的配合过程画得明明白白：
+
+```mermaid
+flowchart TD
+    A[v-if/v-show 状态变化] --> B{进入还是离开?}
+    B -->|进入| C[Transition添加 enter-active-class]
+    C --> D[Animate.css的 animate__bounceIn 动画播放]
+    D --> E[动画结束后移除类名]
+    E --> F[元素正常显示]
+    B -->|离开| G[Transition添加 leave-active-class]
+    G --> H[Animate.css的 animate__bounceOut 动画播放]
+    H --> I[动画结束后移除类名]
+    I --> J[元素从DOM移除或隐藏]
+
+    style A fill:#e1f5fe
+    style F fill:#c8e6c9
+    style J fill:#ffcdd2
+```
+
+简单来说，整个流程就是：你切换状态 → Transition在合适的时机添加Animate.css的类名 → Animate.css的`@keyframes`动画开始播放 → 播完之后Transition把类名移掉 → 过渡完成。你一行`@keyframes`都不用写，全让Animate.css替你干了。
+
+## 三、transition和animation同时存在会打架？type属性来调解
+
+### 问题场景
+
+有时候你可能会在同一个元素上同时使用CSS transition和CSS animation。比如，你用Animate.css的`animate__bounceIn`（这是一个`@keyframes` animation）做进入动画，同时又用CSS transition来控制元素的某个属性变化。这时候Vue就犯难了——它该以哪个的时长为准来决定过渡什么时候结束呢？
+
+Vue的默认行为是：**取transition和animation中时长更长的那个**作为过渡持续时间。但这往往不是你想要的，比如你的animation是1秒，transition是0.3秒，Vue会等1秒才认为过渡结束，但你的transition早就结束了，中间那0.7秒就干等着，体验上可能不对劲。
+
+### type属性登场
+
+Transition组件提供了一个`type`属性，让你明确告诉Vue"以谁为准"：
+
+- `type="transition"`：以CSS transition的时长为准
+- `type="animation"`：以CSS animation的时长为准
+
+打个比方，你定了两个闹钟，一个7点响，一个7点半响。Vue默认听那个响得更晚的，但你可以说"我只听7点那个"，这就是type属性干的事。
+
+### 代码示例
+
+来看个具体例子，一个元素同时有transition和animation：
+
+```vue
+<template>
+  <div>
+    <!-- 不指定type：Vue会取较长的时长，可能导致时序问题 -->
+    <h4>不指定type（默认行为）</h4>
+    <Transition
+      enter-active-class="animate__animated animate__bounceIn my-transition-enter"
+      leave-active-class="animate__animated animate__bounceOut my-transition-leave"
+    >
+      <div v-if="show1" class="box">默认行为</div>
+    </Transition>
+    <button @click="show1 = !show1">切换（默认）</button>
+
+    <!-- 指定type="animation"：以animation的时长为准 -->
+    <h4>type="animation"</h4>
+    <Transition
+      type="animation"
+      enter-active-class="animate__animated animate__bounceIn my-transition-enter"
+      leave-active-class="animate__animated animate__bounceOut my-transition-leave"
+    >
+      <div v-if="show2" class="box">以animation为准</div>
+    </Transition>
+    <button @click="show2 = !show2">切换（animation）</button>
+
+    <!-- 指定type="transition"：以transition的时长为准 -->
+    <h4>type="transition"</h4>
+    <Transition
+      type="transition"
+      enter-active-class="animate__animated animate__bounceIn my-transition-enter"
+      leave-active-class="animate__animated animate__bounceOut my-transition-leave"
+    >
+      <div v-if="show3" class="box">以transition为准</div>
+    </Transition>
+    <button @click="show3 = !show3">切换（transition）</button>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+// 三组独立的显示/隐藏状态
+const show1 = ref(true);
+const show2 = ref(true);
+const show3 = ref(true);
+</script>
+
+<style>
+/* 同时定义了transition和animation的样式 */
+.my-transition-enter {
+  /* 这个transition时长是0.3秒 */
+  transition: opacity 0.3s ease;
+}
+
+.my-transition-leave {
+  /* 这个transition时长也是0.3秒 */
+  transition: opacity 0.3s ease;
+}
+
+/* Animate.css的bounceIn/bounceOut默认是1秒 */
+/* 当type="transition"时，Vue会在0.3秒后认为过渡结束 */
+/* 当type="animation"时，Vue会在1秒后认为过渡结束 */
+
+.box {
+  width: 200px;
+  height: 100px;
+  background: linear-gradient(135deg, #fa709a, #fee140);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  font-size: 16px;
+  margin: 10px 0;
+}
+
+h4 {
+  margin-top: 20px;
+}
+
+button {
+  padding: 6px 14px;
+  border: none;
+  border-radius: 4px;
+  background: #333;
+  color: white;
+  cursor: pointer;
+  margin-bottom: 10px;
+}
+</style>
+```
+
+在这个例子里，每个元素同时有Animate.css的animation（1秒）和CSS transition（0.3秒）。当你指定`type="animation"`时，Vue会等animation播完（1秒）才认为过渡结束；指定`type="transition"`时，Vue只等0.3秒就认为过渡结束了。
+
+实际开发中，如果你用的是Animate.css这种纯animation库，一般设`type="animation"`就行。如果你同时还有transition在控制别的属性，那就根据你希望以哪个为准来选择。
+
+### type属性的选择流程
+
+```mermaid
+flowchart TD
+    A[元素同时有transition和animation] --> B{Vue如何判断过渡结束?}
+    B --> C[默认: 取较长的时长]
+    C --> D[可能导致时序不匹配]
+    D --> E[需要type属性来明确指定]
+    E --> F{你的动画主要靠谁?}
+    F -->|靠@keyframes animation| G[type=&quot;animation&quot;]
+    F -->|靠CSS transition| H[type=&quot;transition&quot;]
+    G --> I[Vue以animation时长为准]
+    H --> J[Vue以transition时长为准]
+
+    style A fill:#fff3e0
+    style E fill:#e8f5e9
+    style G fill:#e3f2fd
+    style H fill:#fce4ec
+```
+
+## 四、性能那点事——哪些属性动画快，哪些会卡
+
+做动画的时候，性能是个绕不开的话题。不是所有CSS属性做动画都一样快的，有些属性动画起来丝般顺滑，有些就能让页面卡成PPT。
+
+### GPU加速的属性：transform和opacity
+
+`transform`（平移、旋转、缩放、倾斜）和`opacity`（透明度）是做动画的黄金搭档。为啥？因为它们可以被GPU加速。
+
+浏览器渲染页面的时候，正常流程是：JavaScript修改样式 → 浏览器重新计算布局（Layout） → 重新绘制（Paint） → 合成（Composite）。但`transform`和`opacity`有个特权——它们不需要重新计算布局和重新绘制，直接在合成阶段就能搞定。这就像你不需要重新画一整幅画，只需要把画好的图层挪个位置或者调个透明度就行，当然快了。
+
+### 会触发重排的属性：height/width/margin/padding
+
+`height`、`width`、`margin`、`padding`、`top`、`left`这些属性做动画的时候，浏览器每帧都要重新计算布局，然后重新绘制，这个过程叫**重排（Reflow）**。重排是很昂贵的操作，尤其是页面元素多的时候，动画就会掉帧、卡顿。
+
+打个比方，`transform`就像你把一张照片在桌面上滑来滑去，照片本身没变，只是位置变了；而改`width`就像你每滑一下就要重新画一张不同大小的照片，当然累多了。
+
+### 代码对比示例
+
+来看两种方式的对比：
+
+```vue
+<template>
+  <div class="container">
+    <!-- 卡顿写法：用height做动画，每帧触发重排 -->
+    <div class="demo-section">
+      <h4>用height做动画（可能卡顿）</h4>
+      <Transition name="height-fade">
+        <div v-if="showBad" class="box bad-box">height动画</div>
+      </Transition>
+      <button @click="showBad = !showBad">切换height动画</button>
+    </div>
+
+    <!-- 流畅写法：用transform做动画，GPU加速 -->
+    <div class="demo-section">
+      <h4>用transform做动画（丝滑）</h4>
+      <Transition name="transform-fade">
+        <div v-if="showGood" class="box good-box">transform动画</div>
+      </Transition>
+      <button @click="showGood = !showGood">切换transform动画</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+const showBad = ref(true);
+const showGood = ref(true);
+</script>
+
+<style>
+/* 卡顿写法：height从0到100px，每帧都要重新计算布局 */
+.height-fade-enter-active,
+.height-fade-leave-active {
+  transition:
+    height 0.5s ease,
+    opacity 0.5s ease;
+  /* height的变化会触发重排，性能差 */
+}
+
+.height-fade-enter-from,
+.height-fade-leave-to {
+  height: 0;
+  opacity: 0;
+  overflow: hidden;
+}
+
+.height-fade-enter-to,
+.height-fade-leave-from {
+  height: 100px;
+  opacity: 1;
+}
+
+/* 流畅写法：用scaleY模拟高度变化，不触发重排 */
+.transform-fade-enter-active,
+.transform-fade-leave-active {
+  transition:
+    transform 0.5s ease,
+    opacity 0.5s ease;
+  /* transform由GPU加速，性能好 */
+}
+
+.transform-fade-enter-from,
+.transform-fade-leave-to {
+  transform: scaleY(0);
+  opacity: 0;
+  transform-origin: top;
+}
+
+.transform-fade-enter-to,
+.transform-fade-leave-from {
+  transform: scaleY(1);
+  opacity: 1;
+  transform-origin: top;
+}
+
+.box {
+  width: 200px;
+  height: 100px;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  font-size: 16px;
+  margin: 10px 0;
+}
+
+.bad-box {
+  background: linear-gradient(135deg, #ff6b6b, #ee5a24);
+}
+
+.good-box {
+  background: linear-gradient(135deg, #26de81, #20bf6b);
+}
+
+.demo-section {
+  margin-bottom: 30px;
+}
+
+button {
+  padding: 6px 14px;
+  border: none;
+  border-radius: 4px;
+  background: #333;
+  color: white;
+  cursor: pointer;
+}
+</style>
+```
+
+### 性能对比一览
+
+| 属性               | 是否触发重排     | GPU加速 | 动画流畅度 | 官方推荐 |
+| ------------------ | ---------------- | ------- | ---------- | -------- |
+| `transform`        | 否               | 是      | 丝滑       | 推荐     |
+| `opacity`          | 否               | 是      | 丝滑       | 推荐     |
+| `height/width`     | 是               | 否      | 可能卡顿   | 不推荐   |
+| `margin/padding`   | 是               | 否      | 可能卡顿   | 不推荐   |
+| `top/left`         | 是               | 否      | 可能卡顿   | 不推荐   |
+| `background-color` | 否（只触发重绘） | 否      | 一般       | 可用     |
+
+Vue官方文档也明确建议：**优先使用`transform`和`opacity`来做动画**。如果你的动画效果需要"高度展开"这种视觉，用`scaleY`来模拟比直接改`height`要流畅得多。
+
+### 用will-change提前告知浏览器
+
+如果你知道某个元素马上要做动画，可以提前用`will-change`属性告诉浏览器"这个属性要变了，你提前准备一下"：
+
+```css
+.box {
+  /* 告诉浏览器transform和opacity即将变化，提前创建合成层 */
+  will-change: transform, opacity;
+}
+```
+
+但注意，`will-change`不能滥用。如果你给页面上所有元素都加上`will-change`，反而会占用大量GPU内存，适得其反。只在确实要做动画的元素上用就行。
+
+## 课后 Quiz
+
+### Quiz 1：Transition组件的6个自定义类名prop分别是什么？它们和默认类名怎么对应？
+
+**答案解析：**
+
+6个自定义类名prop分别是：
+
+1. `enter-from-class` → 对应默认的`v-enter-from`，进入动画的起始状态
+2. `enter-active-class` → 对应默认的`v-enter-active`，进入动画的整个过程
+3. `enter-to-class` → 对应默认的`v-enter-to`，进入动画的结束状态
+4. `leave-from-class` → 对应默认的`v-leave-from`，离开动画的起始状态
+5. `leave-active-class` → 对应默认的`v-leave-active`，离开动画的整个过程
+6. `leave-to-class` → 对应默认的`v-leave-to`，离开动画的结束状态
+
+如果你给Transition设置了`name="fade"`，那默认类名就变成`fade-enter-from`这种格式。而自定义类名prop的优先级更高，设置了自定义prop后，对应的默认类名就不会被添加了。
+
+### Quiz 2：在Transition中使用Animate.css时，为什么通常只需要指定`enter-active-class`和`leave-active-class`，而不需要指定`enter-from-class`等prop？
+
+**答案解析：**
+
+因为Animate.css的动画是基于`@keyframes`的CSS animation，而不是CSS transition。`@keyframes`动画自己就定义了起始帧（from/0%）和结束帧（to/100%），不需要外部再指定初始状态和结束状态。
+
+而CSS transition需要你分别定义"从哪个状态开始"（enter-from）和"到哪个状态结束"（enter-to），浏览器才能计算中间帧。所以用CSS transition时，你需要指定from和to；用CSS animation（如Animate.css）时，只需要指定用哪个动画就行。
+
+不过有个细节要注意：Animate.css的每个动画类名前面都要加上`animate__animated`这个基础类，比如`enter-active-class="animate__animated animate__bounceIn"`，别忘了这个。
+
+### Quiz 3：当元素同时有CSS transition和CSS animation时，`type`属性设为`"transition"`和`"animation"`有什么区别？什么场景下该用哪个？
+
+**答案解析：**
+
+区别在于Vue以哪个的时长来判断过渡何时结束：
+
+- `type="transition"`：Vue以CSS transition的时长为准。当transition结束后，Vue就认为整个过渡过程结束了，即使animation还没播完。
+- `type="animation"`：Vue以CSS animation的时长为准。当animation结束后，Vue才认为过渡过程结束。
+
+选择场景：
+
+- 如果你主要用Animate.css等animation库做动画，同时元素上还有一点transition做辅助效果，一般设`type="animation"`，让动画完整播完。
+- 如果你主要用CSS transition做过渡，animation只是个点缀效果，设`type="transition"`，以transition的节奏为准。
+- 如果只有transition或只有animation其中一种，那type属性其实不需要设置，Vue自己能判断。
+
+## 常见报错解决方案
+
+### 报错1：Animate.css动画不生效，元素直接出现/消失没有动画
+
+**原因分析：**
+
+最常见的原因是忘记加`animate__animated`这个基础类。Animate.css要求每个动画都必须搭配`animate__animated`类才能生效，它内部通过这个类来设置`animation-duration`等基础属性。如果你只写了`animate__bounceIn`而没写`animate__animated`，动画根本不会播放。
+
+另一个常见原因是忘记在入口文件引入Animate.css的样式文件`import 'animate.css'`，导致类名虽然写了但样式不存在。
+
+**解决方案：**
+
+1. 确保每个动画类名前都加上`animate__animated`：
+
+```vue
+<!-- 错误写法：缺少animate__animated -->
+<Transition
+  enter-active-class="animate__bounceIn"
+  leave-active-class="animate__bounceOut"
+>
+
+<!-- 正确写法：加上animate__animated -->
+<Transition
+  enter-active-class="animate__animated animate__bounceIn"
+  leave-active-class="animate__animated animate__bounceOut"
+>
+```
+
+2. 确保在`main.js`中引入了样式文件：
+
+```js
+import "animate.css";
+```
+
+3. 检查浏览器开发者工具的Elements面板，确认类名是否被正确添加到元素上。
+
+### 报错2：设置了type属性后动画被截断，没播完就消失了
+
+**原因分析：**
+
+当`type="transition"`但实际动画主要靠animation驱动时，Vue会在transition时长结束后就认为过渡完成，提前移除元素或类名。比如你的transition只有0.3秒，但animation需要1秒，Vue在0.3秒时就结束了过渡，animation还没播完就被打断了。
+
+**解决方案：**
+
+1. 如果你的动画主要靠`@keyframes`（如Animate.css），设`type="animation"`：
+
+```vue
+<Transition
+  type="animation"
+  enter-active-class="animate__animated animate__bounceIn"
+  leave-active-class="animate__animated animate__bounceOut"
+>
+```
+
+2. 如果确实需要同时使用transition和animation，用`duration`属性显式指定过渡时长：
+
+```vue
+<!-- 显式指定过渡时长为1秒，跟animation时长一致 -->
+<Transition :duration="1000">
+```
+
+3. 也可以传入对象分别指定进入和离开的时长：
+
+```vue
+<Transition :duration="{ enter: 1000, leave: 800 }">
+```
+
+### 报错3：自定义类名prop设置了但没生效，还是用的默认v-类名
+
+**原因分析：**
+
+这通常是因为prop名写错了。Vue 3的Transition组件支持这6个prop名：`enter-from-class`、`enter-active-class`、`enter-to-class`、`leave-from-class`、`leave-active-class`、`leave-to-class`。注意是连字符格式，不是驼峰格式。如果你写成了`enterFromClass`这种驼峰格式，在模板里是不生效的（Vue模板里prop要用kebab-case）。
+
+另一个原因是把prop写在了子元素上而不是`<Transition>`组件上。自定义类名prop必须写在`<Transition>`标签上，不能写在被包裹的元素上。
+
+**解决方案：**
+
+1. 确保prop名使用kebab-case格式：
+
+```vue
+<!-- 错误写法：驼峰格式在模板中不生效 -->
+<Transition enterFromClass="my-enter">
+
+<!-- 正确写法：kebab-case格式 -->
+<Transition enter-from-class="my-enter">
+```
+
+2. 确保prop写在Transition组件上：
+
+```vue
+<!-- 错误写法：prop写在了子元素上 -->
+<Transition>
+  <div v-if="show" enter-active-class="animate__animated animate__bounceIn">内容</div>
+</Transition>
+
+<!-- 正确写法：prop写在Transition组件上 -->
+<Transition enter-active-class="animate__animated animate__bounceIn">
+  <div v-if="show">内容</div>
+</Transition>
+```
+
+3. 如果你在JSX中使用，需要用驼峰格式`enterFromClass`，因为JSX不支持kebab-case的prop名。
+
+参考链接：https://vuejs.org/guide/built-ins/transition.html
+
+余下文章内容请点击跳转至 个人博客页面 或者 扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`，阅读完整的文章：[不想写CSS类名？用自定义类名和Animate.css让动画飞起来](https://blog.cmdragon.cn/posts/b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3/)
+
+<details>
+<summary>往期文章归档</summary>
+
+- [Vue 3 静态与动态 Props 如何传递？TypeScript 类型约束有何必要？](https://blog.cmdragon.cn/posts/94ab48753b64780ca3ab7a7115ae8522/)
+- [Vue 3中组件局部注册的优势与实现方式如何？](https://blog.cmdragon.cn/posts/dbf576e744870f6de26fd8a2e03e47da/)
+- [如何在Vue3中优化生命周期钩子性能并规避常见陷阱？](https://blog.cmdragon.cn/posts/12d98b3b9ccd6c19a1b169d720ac5c80/)
+- [Vue 3 Composition API生命周期钩子：如何实现从基础理解到高阶复用？](https://blog.cmdragon.cn/posts/8884e2b70287fcb263c57648eeb27419/)
+- [Vue 3生命周期钩子实战指南：如何正确选择onMounted、onUpdated与onUnmounted的应用场景？](https://blog.cmdragon.cn/posts/883c6dbc50ae4183770a4462e0b8ae4d/)
+- [Vue 3中生命周期钩子与响应式系统如何实现协同工作？](https://blog.cmdragon.cn/posts/70dad360ffa9dce14d0d69611b8cb019/)
+- [Vue 3组件生命周期钩子的执行顺序与使用场景是什么？](https://blog.cmdragon.cn/posts/db44294a78dc9f666f67b053f6c83567/)
+- [Vue组件全局注册与局部注册如何抉择？](https://blog.cmdragon.cn/posts/43ead630ea17da65d99ad2eb8188e472/)
+- [Vue3组件化开发中，Props与Emits如何实现数据流转与事件协作？](https://blog.cmdragon.cn/posts/8cff7d2df113da66ea7be560c4d1d22a/)
+- [Vue 3模板引用如何与其他特性协同实现复杂交互？](https://blog.cmdragon.cn/posts/331bf75d114ab09116eadfcdca602b58/)
+- [Vue 3 v-for中模板引用如何实现高效管理与动态控制？](https://blog.cmdragon.cn/posts/cb380897ddc3578b180ecf8843c774c1/)
+- [Vue 3的defineExpose：如何突破script setup组件默认封装，实现精准的父子通讯？](https://blog.cmdragon.cn/posts/202ae0f4acde7128e0e31baf63732fb5/)
+- [Vue 3模板引用的生命周期时机如何把握？常见陷阱该如何避免？](https://blog.cmdragon.cn/posts/7d2a0f6555ecbe92afd7d2491c427463/)
+- [Vue 3模板引用如何实现父组件与子组件的高效交互？](https://blog.cmdragon.cn/posts/3fb7bdd84128b7efaaa1c979e1f28dee/)
+- [Vue中为何需要模板引用？又如何高效实现DOM与组件实例的直接访问？](https://blog.cmdragon.cn/posts/23f3464ba16c7054b4783cded50c04c6/)
+
+</details>
+
+<details>
+<summary>免费好用的热门在线工具</summary>
+
+- [多直播聚合器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/multi-live-aggregator)
+- [Proto文件生成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/proto-file-generator)
+- [图片转粒子 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/image-to-particles)
+- [视频下载器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/video-downloader)
+- [文件格式转换器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/file-converter)
+- [M3U8在线播放器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/m3u8-player)
+- [快图设计 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/quick-image-design)
+- [高级文字转图片转换器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/text-to-image-advanced)
+- [RAID 计算器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/raid-calculator)
+- [在线PS - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/photoshop-online)
+- [Mermaid 在线编辑器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/mermaid-live-editor)
+- [数学求解计算器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/math-solver-calculator)
+- [智能提词器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/smart-teleprompter)
+- [魔法简历 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/magic-resume)
+- [Image Puzzle Tool - 图片拼图工具 | By cmdragon](https://tools.cmdragon.cn/zh/apps/image-puzzle-tool)
+- [字幕下载工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/subtitle-downloader)
+- [歌词生成工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/lyrics-generator)
+- [网盘资源聚合搜索 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/cloud-drive-search)
+- [ASCII字符画生成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/ascii-art-generator)
+- [JSON Web Tokens 工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/jwt-tool)
+- [Bcrypt 密码工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/bcrypt-tool)
+- [GIF 合成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/gif-composer)
+- [GIF 分解器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/gif-decomposer)
+- [文本隐写术 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/text-steganography)
+- [CMDragon 在线工具 - 高级AI工具箱与开发者套件 | 免费好用的在线工具](https://tools.cmdragon.cn/zh)
+- [应用商店 - 发现1000+提升效率与开发的AI工具和实用程序 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps?category=trending)
+- [CMDragon 更新日志 - 最新更新、功能与改进 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/changelog)
+- [支持我们 - 成为赞助者 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/sponsor)
+- [AI文本生成图像 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/text-to-image-ai)
+- [临时邮箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/temp-email)
+- [二维码解析器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/qrcode-parser)
+- [文本转思维导图 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/text-to-mindmap)
+- [正则表达式可视化工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/regex-visualizer)
+- [文件隐写工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/steganography-tool)
+- [IPTV 频道探索器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/iptv-explorer)
+- [快传 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/snapdrop)
+- [随机抽奖工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/lucky-draw)
+- [动漫场景查找器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/anime-scene-finder)
+- [时间工具箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/time-toolkit)
+- [网速测试 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/speed-test)
+- [AI 智能抠图工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/background-remover)
+- [背景替换工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/background-replacer)
+- [艺术二维码生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/artistic-qrcode)
+- [Open Graph 元标签生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/open-graph-generator)
+- [图像对比工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/image-comparison)
+- [图片压缩专业版 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/image-compressor)
+- [密码生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/password-generator)
+- [SVG优化器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/svg-optimizer)
+- [调色板生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/color-palette)
+- [在线节拍器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/online-metronome)
+- [IP归属地查询 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/ip-geolocation)
+- [CSS网格布局生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/css-grid-layout)
+- [邮箱验证工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/email-validator)
+- [书法练习字帖 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/calligraphy-practice)
+- [金融计算器套件 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/finance-calculator-suite)
+- [中国亲戚关系计算器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/chinese-kinship-calculator)
+- [Protocol Buffer 工具箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/protobuf-toolkit)
+- [IP归属地查询 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/ip-geolocation)
+- [图片无损放大 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/image-upscaler)
+- [文本比较工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/text-compare)
+- [IP批量查询工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/ip-batch-lookup)
+- [域名查询工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/domain-finder)
+- [DNS工具箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/dns-toolkit)
+- [网站图标生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/favicon-generator)
+- [XML Sitemap](https://tools.cmdragon.cn/sitemap_index.xml)
+
+</details>

--- a/content/posts/front_end/vue/两个元素切换时撞车了咋办？过渡模式out-in和in-out来救场.md
+++ b/content/posts/front_end/vue/两个元素切换时撞车了咋办？过渡模式out-in和in-out来救场.md
@@ -1,0 +1,864 @@
+---
+url: /posts/d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5/
+title: 两个元素切换时撞车了咋办？过渡模式out-in和in-out来救场
+date: 2026-05-31T13:00:00+08:00
+lastmod: 2026-05-31T13:00:00+08:00
+author: cmdragon
+cover: https://api2.cmdragon.cn/upload/cmder/images/2026年6月3日 21_45_47.png
+
+summary: Vue 3 Transition组件在多个元素切换时，默认是同时执行进入和离开动画，容易导致布局重叠。本文详解过渡模式mode="out-in"和mode="in-out"的区别、v-if/v-else元素切换、动态组件切换动画的完整实现。
+
+categories:
+  - vue
+
+tags:
+  - 基础入门
+  - Transition
+  - 过渡模式
+  - out-in
+  - in-out
+  - 动态组件
+  - 元素切换
+---
+
+<img src="https://api2.cmdragon.cn/upload/cmder/images/2026年6月3日 21_45_47.png" title="cover.png" alt="cmdragon_cn.png"/>
+
+<img src="https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg" title="cmdragon_cn.png" alt="cmdragon_cn.png"/>
+
+扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`
+
+[发现1000+提升效率与开发的AI工具和实用程序](https://tools.cmdragon.cn/zh/apps?category=ai_chat)：https://tools.cmdragon.cn/zh/apps?category=ai_chat
+
+## 一、默认行为——两个元素同时动画，撞车了
+
+上一篇咱们聊了Transition组件的6个CSS类名，知道了元素怎么"进场"和"退场"。但那都是单个元素的情况，如果两个元素要切换呢？比如一个`v-if`和一个`v-else`，一个走了另一个来，这俩动画怎么配合？
+
+先说结论：默认情况下，Vue会让进入动画和离开动画**同时执行**。听起来好像没啥问题，但你想想——旧元素还没走干净呢，新元素就挤进来了，两个元素同时占据同一块DOM空间，那画面……啧啧，跟两个人同时挤一扇门一样，谁也别想好好过。
+
+来，看个例子就明白了：
+
+```vue
+<template>
+  <!-- 没有设置mode，默认同时执行进入和离开 -->
+  <Transition>
+    <!-- v-if和v-else互斥切换，但动画同时发生 -->
+    <div v-if="isOn" key="on" class="box on">开启状态</div>
+    <div v-else key="off" class="box off">关闭状态</div>
+  </Transition>
+  <!-- 按钮切换状态 -->
+  <button @click="isOn = !isOn">切换</button>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+// 控制显示哪个元素
+const isOn = ref(true);
+</script>
+
+<style>
+/* 两个box的基础样式 */
+.box {
+  width: 200px;
+  height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  font-weight: bold;
+  color: white;
+}
+
+/* 开启状态的背景色 */
+.on {
+  background: #42b883;
+}
+
+/* 关闭状态的背景色 */
+.off {
+  background: #e74c3c;
+}
+
+/* 进入和离开的过渡效果 */
+.v-enter-active,
+.v-leave-active {
+  transition: all 0.5s ease;
+}
+
+/* 进入起始：从左侧滑入且透明 */
+.v-enter-from {
+  opacity: 0;
+  transform: translateX(-30px);
+}
+
+/* 离开结束：向右侧滑出且透明 */
+.v-leave-to {
+  opacity: 0;
+  transform: translateX(30px);
+}
+</style>
+```
+
+你运行一下就知道了——点击切换按钮的时候，旧元素还在往右滑出去呢，新元素已经从左边挤进来了。两个元素叠在一起，布局直接乱套，视觉上就是一坨糊在一起的东西在闪。
+
+这就是默认行为的"撞车"问题。Vue官方文档也明确说了：当两个元素切换时，默认的进入和离开是同时发生的，这可能导致布局重叠。
+
+打个比方吧：想象一个房间只有一扇门，里面的人要出来，外面的人要进去。如果两个人同时挤，那肯定卡在门口对吧？得有个先后顺序才行。这就是过渡模式（Transition Mode）要解决的问题。
+
+```mermaid
+flowchart LR
+    A[切换触发] --> B[离开动画开始]
+    A --> C[进入动画开始]
+    B --> D[两个元素同时存在于DOM]
+    C --> D
+    D --> E[布局重叠/闪烁]
+    style E fill:#e74c3c,color:#fff
+    style A fill:#42b883,color:#fff
+```
+
+上图就是默认行为的流程——进入和离开同时触发，两个元素在DOM里"撞车"，导致布局重叠和视觉闪烁。那咋解决呢？往下看。
+
+## 二、mode="out-in"——先走后进，最常用
+
+Vue给Transition组件提供了一个`mode`属性，专门用来控制进入和离开动画的执行顺序。最常用的就是`mode="out-in"`，意思是：**离开动画先执行完，再执行进入动画**。
+
+就像换班一样——上一班的人先走了，下一班的人再进来，井然有序，谁也不碍谁。
+
+用法特别简单，在`<Transition>`上加一个`mode`属性就行：
+
+```vue
+<template>
+  <!-- 加上mode="out-in"，先走后进 -->
+  <Transition mode="out-in">
+    <!-- 每个元素必须加key，否则Vue会复用元素导致动画不触发 -->
+    <div v-if="isOn" key="on" class="box on">开启状态</div>
+    <div v-else key="off" class="box off">关闭状态</div>
+  </Transition>
+  <button @click="isOn = !isOn">切换</button>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+// 控制显示哪个元素
+const isOn = ref(true);
+</script>
+
+<style>
+.box {
+  width: 200px;
+  height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  font-weight: bold;
+  color: white;
+}
+
+.on {
+  background: #42b883;
+}
+
+.off {
+  background: #e74c3c;
+}
+
+/* 进入动画用ease-in-out，更丝滑 */
+.v-enter-active {
+  transition: all 0.3s ease-in;
+}
+
+/* 离开动画用ease-out，快速离场 */
+.v-leave-active {
+  transition: all 0.3s ease-out;
+}
+
+.v-enter-from {
+  opacity: 0;
+  transform: translateX(-30px);
+}
+
+.v-leave-to {
+  opacity: 0;
+  transform: translateX(30px);
+}
+</style>
+```
+
+加了`mode="out-in"`之后，切换流程就变成了这样：
+
+1. 点击切换按钮
+2. 旧元素执行离开动画（往右滑出+淡出）
+3. 离开动画结束，旧元素从DOM中移除
+4. 新元素执行进入动画（从左滑入+淡入）
+
+整个过程清清爽爽，没有任何重叠。这也是为什么`out-in`是最常用的模式——绝大多数切换场景用它就对了。
+
+来看一下`out-in`模式的完整流程图：
+
+```mermaid
+flowchart TD
+    A[切换触发] --> B[旧元素执行离开动画]
+    B --> C{离开动画完成?}
+    C -->|否| B
+    C -->|是| D[旧元素从DOM移除]
+    D --> E[新元素执行进入动画]
+    E --> F{进入动画完成?}
+    F -->|否| E
+    F -->|是| G[切换完成，新元素正常显示]
+    style A fill:#42b883,color:#fff
+    style G fill:#42b883,color:#fff
+    style D fill:#f39c12,color:#fff
+```
+
+### 啥时候用out-in？
+
+基本上90%的元素切换场景都适合用`out-in`：
+
+- **Tab标签页切换**：旧内容先淡出，新内容再淡入
+- **弹窗替换**：一个弹窗关了，另一个再开
+- **步骤向导**：上一步的内容先走，下一步的内容再进来
+- **登录/注册切换**：登录表单先消失，注册表单再出现
+
+总之，只要你不希望两个元素同时出现在同一个位置，用`out-in`准没错。
+
+## 三、mode="in-out"——先进后走，少用但有用
+
+跟`out-in`相反，`mode="in-out"`的意思是：**进入动画先执行，再执行离开动画**。新元素先挤进来，旧元素再走。
+
+你可能会想：这不是更挤了吗？确实，大多数情况下用`in-out`会让两个元素短暂重叠，看起来更乱。但在某些特定场景下，它反而能做出很酷的效果。
+
+打个比方：接力赛交接棒——新选手先跑起来，旧选手再把棒交过去，然后旧选手才退场。这种"先进后走"的效果，适合那种新元素需要从旧元素的位置"推"出来的场景。
+
+```vue
+<template>
+  <!-- mode="in-out"，先进后走 -->
+  <Transition mode="in-out">
+    <div v-if="isOn" key="on" class="box on">开启状态</div>
+    <div v-else key="off" class="box off">关闭状态</div>
+  </Transition>
+  <button @click="isOn = !isOn">切换</button>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+const isOn = ref(true);
+</script>
+
+<style>
+.box {
+  width: 200px;
+  height: 80px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  font-weight: bold;
+  color: white;
+  /* 关键：绝对定位，让新元素可以叠在旧元素上方 */
+  position: absolute;
+}
+
+.on {
+  background: #42b883;
+}
+
+.off {
+  background: #e74c3c;
+}
+
+/* 进入动画：从0缩放到正常大小 */
+.v-enter-active {
+  transition: all 0.3s ease-out;
+}
+
+/* 离开动画：从正常大小缩放到0 */
+.v-leave-active {
+  transition: all 0.3s ease-in;
+}
+
+/* 进入起始：缩小且透明 */
+.v-enter-from {
+  opacity: 0;
+  transform: scale(0.8);
+}
+
+/* 离开结束：放大且透明 */
+.v-leave-to {
+  opacity: 0;
+  transform: scale(1.2);
+}
+</style>
+```
+
+注意上面代码里有个关键点：`.box`加了`position: absolute`。因为`in-out`模式下新元素先进入，旧元素后离开，两个元素会短暂共存于DOM中。如果不用绝对定位，两个块级元素会上下排列，效果就完全不对了。用绝对定位让它们叠在同一位置，新元素"盖"在旧元素上面，看起来就像新元素把旧元素"推"走了。
+
+`in-out`的流程如下：
+
+```mermaid
+flowchart TD
+    A[切换触发] --> B[新元素执行进入动画]
+    B --> C{进入动画完成?}
+    C -->|否| B
+    C -->|是| D[旧元素执行离开动画]
+    D --> E{离开动画完成?}
+    E -->|否| D
+    E -->|是| F[旧元素从DOM移除，切换完成]
+    style A fill:#42b883,color:#fff
+    style F fill:#42b883,color:#fff
+    style B fill:#f39c12,color:#fff
+```
+
+### 啥时候用in-out？
+
+`in-out`用得确实少，但以下场景它就特别合适：
+
+- **按钮状态切换**：比如"收藏"变"已收藏"，新状态从原位置弹出来，旧状态再消失，视觉上很连贯
+- **卡片翻转效果**：正面先出现，背面再消失，模拟3D翻转
+- **滑动覆盖**：新内容从下方滑入覆盖旧内容，旧内容再淡出
+
+一句话总结：当你希望新元素"推走"旧元素，而不是旧元素"让位"给新元素的时候，用`in-out`。
+
+### out-in和in-out的对比
+
+| 对比项   | mode="out-in"      | mode="in-out"              |
+| -------- | ------------------ | -------------------------- |
+| 执行顺序 | 离开先，进入后     | 进入先，离开后             |
+| 元素共存 | 不会共存           | 短暂共存                   |
+| 布局影响 | 无重叠             | 需要处理重叠（如绝对定位） |
+| 使用频率 | 非常高，90%场景    | 较低，特定场景             |
+| 典型场景 | Tab切换、表单切换  | 按钮状态、覆盖式切换       |
+| 视觉感受 | 旧走新来，干净利落 | 新推旧走，连贯流畅         |
+
+## 四、v-if/v-else/v-else-if的切换动画
+
+前面举的例子都是`v-if`和`v-else`两个分支的切换，实际上Vue的条件渲染还有`v-else-if`，可以搞出更多分支。不管是两个还是三个四个分支，过渡模式的用法都是一样的。
+
+但有一个**超级重要的坑**必须提醒你：**每个分支的元素必须加不同的`key`！**
+
+为啥？因为Vue的虚拟DOM有个"复用策略"——如果两个元素标签相同（比如都是`<div>`），Vue会认为它们是同一个元素，只更新内容而不重新创建。这意味着进入和离开动画都不会触发，你写了半天Transition结果啥效果都没有。
+
+来看一个Tab切换的完整示例：
+
+```vue
+<template>
+  <div class="tab-demo">
+    <!-- 三个Tab按钮 -->
+    <div class="tab-buttons">
+      <button
+        v-for="tab in tabs"
+        :key="tab.id"
+        :class="{ active: currentTab === tab.id }"
+        @click="currentTab = tab.id"
+      >
+        {{ tab.label }}
+      </button>
+    </div>
+
+    <!-- Transition包裹切换内容，使用out-in模式 -->
+    <Transition name="fade-slide" mode="out-in">
+      <!-- 每个分支必须加不同的key！ -->
+      <div v-if="currentTab === 'home'" key="home" class="tab-content">
+        🏠 首页：欢迎来到我的博客！
+      </div>
+      <div v-else-if="currentTab === 'about'" key="about" class="tab-content">
+        👤 关于：我是一名前端开发者
+      </div>
+      <div v-else key="contact" class="tab-content">
+        📧 联系：hello@example.com
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+// 当前选中的Tab
+const currentTab = ref("home");
+
+// Tab列表数据
+const tabs = [
+  { id: "home", label: "首页" },
+  { id: "about", label: "关于" },
+  { id: "contact", label: "联系" },
+];
+</script>
+
+<style>
+/* Tab按钮区域 */
+.tab-buttons {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+/* Tab按钮样式 */
+.tab-buttons button {
+  padding: 8px 16px;
+  border: 2px solid #42b883;
+  background: white;
+  color: #42b883;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.2s;
+}
+
+/* 激活状态的按钮 */
+.tab-buttons button.active {
+  background: #42b883;
+  color: white;
+}
+
+/* Tab内容区域 */
+.tab-content {
+  padding: 20px;
+  border: 2px solid #e0e0e0;
+  border-radius: 8px;
+  font-size: 16px;
+  min-height: 100px;
+  display: flex;
+  align-items: center;
+}
+
+/* 命名过渡：fade-slide的进入动画 */
+.fade-slide-enter-active {
+  transition: all 0.3s ease-out;
+}
+
+/* 命名过渡：fade-slide的离开动画 */
+.fade-slide-leave-active {
+  transition: all 0.2s ease-in;
+}
+
+/* 进入起始状态 */
+.fade-slide-enter-from {
+  opacity: 0;
+  transform: translateY(10px);
+}
+
+/* 离开结束状态 */
+.fade-slide-leave-to {
+  opacity: 0;
+  transform: translateY(-10px);
+}
+</style>
+```
+
+这里用了**命名过渡**（`name="fade-slide"`），这样CSS类名就变成了`fade-slide-enter-active`而不是默认的`v-enter-active`，避免跟其他Transition组件的样式冲突。这是一个好习惯，推荐每次都用命名过渡。
+
+来看一下`v-if/v-else-if/v-else`配合`mode="out-in"`的完整流程：
+
+```mermaid
+flowchart TD
+    A[用户点击新Tab] --> B[当前内容执行离开动画]
+    B --> C{离开动画完成?}
+    C -->|否| B
+    C -->|是| D[旧内容从DOM移除]
+    D --> E[新内容执行进入动画]
+    E --> F{进入动画完成?}
+    F -->|否| E
+    F -->|是| G[新内容正常显示]
+    style A fill:#42b883,color:#fff
+    style G fill:#42b883,color:#fff
+```
+
+### key不加会咋样？
+
+如果你把上面代码里的`key`去掉，切换Tab的时候你会发现——啥动画都没有，内容直接就变了。因为Vue看到三个`<div>`，觉得它们是同一个元素，只更新了里面的文字，并没有触发进入/离开的过渡。
+
+所以记住这条铁律：**在Transition里用`v-if/v-else`切换时，每个分支必须加不同的`key`！**
+
+## 五、动态组件切换动画
+
+除了`v-if/v-else`的条件切换，Vue还有一种很常见的切换方式——**动态组件**，就是用`<component :is="...">`来动态渲染不同的组件。Transition同样能给动态组件切换加上动画。
+
+用法跟条件渲染差不多，把`<component>`放在`<Transition>`里面就行：
+
+```vue
+<template>
+  <div class="dynamic-demo">
+    <!-- Tab按钮 -->
+    <div class="tab-buttons">
+      <button
+        v-for="tab in tabs"
+        :key="tab.component"
+        :class="{ active: currentTab === tab.component }"
+        @click="currentTab = tab.component"
+      >
+        {{ tab.label }}
+      </button>
+    </div>
+
+    <!-- Transition包裹动态组件，使用out-in模式 -->
+    <Transition name="component-fade" mode="out-in">
+      <!-- 动态组件，:is绑定当前组件名 -->
+      <component :is="currentTab" :key="currentTab" />
+    </Transition>
+  </div>
+</template>
+
+<script setup>
+import { ref, shallowRef } from "vue";
+import HomeTab from "./HomeTab.vue";
+import AboutTab from "./AboutTab.vue";
+import ContactTab from "./ContactTab.vue";
+
+// 当前显示的组件
+const currentTab = shallowRef(HomeTab);
+
+// Tab配置列表
+const tabs = [
+  { label: "首页", component: HomeTab },
+  { label: "关于", component: AboutTab },
+  { label: "联系", component: ContactTab },
+];
+</script>
+
+<style>
+.tab-buttons {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.tab-buttons button {
+  padding: 8px 16px;
+  border: 2px solid #42b883;
+  background: white;
+  color: #42b883;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.2s;
+}
+
+.tab-buttons button.active {
+  background: #42b883;
+  color: white;
+}
+
+/* 命名过渡：component-fade */
+.component-fade-enter-active {
+  transition: opacity 0.3s ease;
+}
+
+.component-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.component-fade-enter-from,
+.component-fade-leave-to {
+  opacity: 0;
+}
+</style>
+```
+
+上面代码里用`shallowRef`而不是`ref`来存储当前组件，这是Vue官方推荐的做法——组件对象不需要深度响应式，用`shallowRef`性能更好。
+
+三个子组件长这样：
+
+```vue
+<!-- HomeTab.vue -->
+<template>
+  <div class="tab-panel">
+    <h3>🏠 首页</h3>
+    <p>欢迎来到我的博客，这里分享Vue 3的技术文章。</p>
+  </div>
+</template>
+
+<style scoped>
+.tab-panel {
+  padding: 20px;
+  border: 2px solid #e0e0e0;
+  border-radius: 8px;
+  min-height: 120px;
+}
+</style>
+```
+
+```vue
+<!-- AboutTab.vue -->
+<template>
+  <div class="tab-panel">
+    <h3>👤 关于</h3>
+    <p>我是一名前端开发者，热爱Vue和开源。</p>
+  </div>
+</template>
+
+<style scoped>
+.tab-panel {
+  padding: 20px;
+  border: 2px solid #e0e0e0;
+  border-radius: 8px;
+  min-height: 120px;
+}
+</style>
+```
+
+```vue
+<!-- ContactTab.vue -->
+<template>
+  <div class="tab-panel">
+    <h3>📧 联系</h3>
+    <p>邮箱：hello@example.com</p>
+  </div>
+</template>
+
+<style scoped>
+.tab-panel {
+  padding: 20px;
+  border: 2px solid #e0e0e0;
+  border-radius: 8px;
+  min-height: 120px;
+}
+</style>
+```
+
+### 动态组件切换的注意事项
+
+1. **必须加`key`**：跟`v-if/v-else`一样，动态组件也需要加`:key`。如果不加，Vue可能会复用同一个组件实例，导致动画不触发或者状态残留。
+
+2. **用`shallowRef`存储组件**：组件对象本身不需要深度响应式，用`shallowRef`可以避免不必要的性能开销。如果你用`ref`，Vue会递归地把组件对象的所有属性都变成响应式的，这完全没必要。
+
+3. **`mode="out-in"`是最佳拍档**：动态组件切换几乎都用`out-in`，因为你不希望两个组件同时出现在页面上。`in-out`会导致两个组件短暂共存，布局容易乱。
+
+4. **组件名和`key`要对应**：如果你用字符串形式的组件名（比如`:is="'HomeTab'"`），确保组件已经全局注册或者通过`components`选项局部注册。更推荐直接用组件对象（像上面的例子那样），这样不需要额外注册。
+
+来看一下动态组件切换的完整流程图：
+
+```mermaid
+flowchart TD
+    A[用户点击新Tab] --> B[当前组件执行离开动画]
+    B --> C{离开动画完成?}
+    C -->|否| B
+    C -->|是| D[旧组件卸载]
+    D --> E[新组件挂载]
+    E --> F[新组件执行进入动画]
+    F --> G{进入动画完成?}
+    G -->|否| F
+    G -->|是| H[新组件正常显示]
+    style A fill:#42b883,color:#fff
+    style H fill:#42b883,color:#fff
+    style D fill:#e74c3c,color:#fff
+    style E fill:#f39c12,color:#fff
+```
+
+注意跟`v-if/v-else`的区别：动态组件切换时，旧组件会**卸载**（触发`onUnmounted`），新组件会**挂载**（触发`onMounted`）。如果你在组件里有副作用（比如定时器、事件监听），记得在`onUnmounted`里清理干净。
+
+## 课后 Quiz
+
+### 问题1：Transition组件默认的进入和离开动画执行方式是什么？会导致什么问题？
+
+**答案解析**：
+
+默认情况下，Transition组件会让进入动画和离开动画**同时执行**。也就是说，当元素A离开的同时，元素B就开始进入了。
+
+这会导致两个问题：
+
+1. **布局重叠**：两个元素同时存在于DOM中，如果它们是块级元素且没有绝对定位，就会上下排列导致布局跳动；如果用了绝对定位，视觉上两个元素会叠在一起。
+2. **视觉闪烁**：两个元素的动画同时播放，过渡效果互相干扰，看起来就像画面在闪烁或者抖动。
+
+解决办法就是设置`mode`属性，用`out-in`或`in-out`来控制执行顺序。
+
+### 问题2：mode="out-in"和mode="in-out"的核心区别是什么？分别适合什么场景？
+
+**答案解析**：
+
+核心区别在于**进入和离开动画的执行顺序**：
+
+- `mode="out-in"`：离开动画先执行完，再执行进入动画。旧元素彻底走了，新元素才进来。适合绝大多数切换场景，比如Tab切换、表单切换、步骤向导等。不会出现元素重叠的问题。
+
+- `mode="in-out"`：进入动画先执行，再执行离开动画。新元素先进来，旧元素再走。适合需要新元素"推走"旧元素的场景，比如按钮状态切换（"收藏"变"已收藏"）、卡片翻转效果等。因为两个元素会短暂共存，通常需要配合绝对定位使用。
+
+选择原则：90%的场景用`out-in`，只有当你明确需要"先进后走"的视觉效果时才用`in-out`。
+
+### 问题3：为什么在Transition中使用v-if/v-else切换时，必须给每个元素加不同的key？
+
+**答案解析**：
+
+因为Vue的虚拟DOM有一个**复用策略**（也叫patch算法）。当Vue发现两个元素的标签名相同（比如都是`<div>`），它会认为这是同一个元素，只更新元素的内容（比如文字、属性），而不会销毁旧元素、创建新元素。
+
+而Transition的进入/离开动画，恰恰依赖于元素的**创建和销毁**。只有元素被插入DOM时才会触发进入动画，只有元素被移除DOM时才会触发离开动画。如果Vue复用了元素，那既没有创建也没有销毁，动画自然就不会触发了。
+
+加了不同的`key`之后，Vue会认为它们是不同的元素，切换时就会先销毁旧元素（触发离开动画），再创建新元素（触发进入动画），动画就能正常工作了。
+
+这也是Vue官方文档强调的一点：当在Transition中使用`v-if/v-else`切换时，始终要为不同分支的元素设置不同的key。
+
+## 常见报错解决方案
+
+### 报错1：Transition组件里的v-if/v-else切换没有动画效果
+
+**产生原因**：
+
+最常见的原因就是**没加`key`**。没有`key`的时候，Vue会复用相同的DOM元素，只更新内容而不触发进入/离开过渡。另外，如果CSS过渡类名写错了（比如用了默认的`v-enter-active`但Transition设了`name`），也会导致样式不生效。
+
+**解决方案**：
+
+1. 给每个条件分支的元素加上不同的`key`属性
+2. 检查CSS类名是否跟Transition的`name`属性匹配。如果设了`name="fade"`，类名应该是`fade-enter-active`而不是`v-enter-active`
+3. 确保CSS过渡属性（`transition`）写在`-enter-active`和`-leave-active`类里，而不是写在`-enter-from`或`-leave-to`里
+
+**预防建议**：养成习惯，在Transition里用条件渲染时，始终给元素加`key`，并且使用命名过渡（`name`属性）避免样式冲突。
+
+### 报错2：mode="in-out"时布局跳动或元素上下排列
+
+**产生原因**：
+
+`in-out`模式下，新元素先进入，旧元素后离开，两个元素会短暂共存于DOM中。如果它们是普通的块级元素（`display: block`），就会上下排列而不是叠在一起，导致布局跳动。
+
+**解决方案**：
+
+1. 给切换的元素加`position: absolute`，让它们脱离文档流，叠在同一位置
+2. 给Transition的父容器加`position: relative`和固定高度，防止容器塌陷
+3. 如果不想用绝对定位，也可以用`display: inline-block`配合固定宽度
+
+```css
+/* 父容器需要相对定位和固定高度 */
+.transition-wrapper {
+  position: relative;
+  height: 80px;
+}
+
+/* 切换的元素绝对定位，叠在一起 */
+.transition-wrapper .box {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+```
+
+**预防建议**：使用`in-out`模式时，提前考虑元素共存时的布局问题，提前设置好定位方案。
+
+### 报错3：动态组件切换时Transition动画不触发
+
+**产生原因**：
+
+动态组件切换时动画不触发，通常有以下几个原因：
+
+1. **没加`:key`**：跟`v-if/v-else`一样，动态组件也需要`:key`来区分不同的组件实例
+2. **组件引用方式不对**：如果用字符串形式的组件名（`:is="'ComponentA'"`），但组件没有全局注册或局部注册，Vue会渲染不出组件，自然也没有动画
+3. **用了`ref`而不是`shallowRef`**：虽然不会直接导致动画不触发，但`ref`会对组件对象做深度响应式处理，可能导致不必要的性能问题和警告
+
+**解决方案**：
+
+1. 给`<component>`加`:key`属性：`<component :is="currentTab" :key="currentTab" />`
+2. 使用组件对象而不是字符串名：`const currentTab = shallowRef(HomeTab)`而不是`const currentTab = ref('HomeTab')`
+3. 确保组件已正确导入和注册
+
+```vue
+<!-- 正确写法 -->
+<Transition name="fade" mode="out-in">
+  <component :is="currentTab" :key="currentTab" />
+</Transition>
+
+<script setup>
+import { shallowRef } from "vue";
+import HomeTab from "./HomeTab.vue";
+import AboutTab from "./AboutTab.vue";
+
+// 用shallowRef存储组件对象
+const currentTab = shallowRef(HomeTab);
+</script>
+```
+
+**预防建议**：动态组件切换时，始终使用`shallowRef`存储组件对象，始终加`:key`属性，始终配合`mode="out-in"`使用。
+
+参考链接：https://vuejs.org/guide/built-ins/transition.html
+
+余下文章内容请点击跳转至 个人博客页面 或者 扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`，阅读完整的文章：[两个元素切换时撞车了咋办？过渡模式out-in和in-out来救场](https://blog.cmdragon.cn/posts/d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5/)
+
+<details>
+<summary>往期文章归档</summary>
+
+- [Vue 3 静态与动态 Props 如何传递？TypeScript 类型约束有何必要？](https://blog.cmdragon.cn/posts/94ab48753b64780ca3ab7a7115ae8522/)
+- [Vue 3中组件局部注册的优势与实现方式如何？](https://blog.cmdragon.cn/posts/dbf576e744870f6de26fd8a2e03e47da/)
+- [如何在Vue3中优化生命周期钩子性能并规避常见陷阱？](https://blog.cmdragon.cn/posts/12d98b3b9ccd6c19a1b169d720ac5c80/)
+- [Vue 3 Composition API生命周期钩子：如何实现从基础理解到高阶复用？](https://blog.cmdragon.cn/posts/8884e2b70287fcb263c57648eeb27419/)
+- [Vue 3生命周期钩子实战指南：如何正确选择onMounted、onUpdated与onUnmounted的应用场景？](https://blog.cmdragon.cn/posts/883c6dbc50ae4183770a4462e0b8ae4d/)
+- [Vue 3中生命周期钩子与响应式系统如何实现协同工作？](https://blog.cmdragon.cn/posts/70dad360ffa9dce14d0d69611b8cb019/)
+- [Vue 3组件生命周期钩子的执行顺序与使用场景是什么？](https://blog.cmdragon.cn/posts/db44294a78dc9f666f67b053f6c83567/)
+- [Vue组件全局注册与局部注册如何抉择？](https://blog.cmdragon.cn/posts/43ead630ea17da65d99ad2eb8188e472/)
+- [Vue3组件化开发中，Props与Emits如何实现数据流转与事件协作？](https://blog.cmdragon.cn/posts/8cff7d2df113da66ea7be560c4d1d22a/)
+- [Vue 3模板引用如何与其他特性协同实现复杂交互？](https://blog.cmdragon.cn/posts/331bf75d114ab09116eadfcdca602b58/)
+- [Vue 3 v-for中模板引用如何实现高效管理与动态控制？](https://blog.cmdragon.cn/posts/cb380897ddc3578b180ecf8843c774c1/)
+- [Vue 3的defineExpose：如何突破script setup组件默认封装，实现精准的父子通讯？](https://blog.cmdragon.cn/posts/202ae0f4acde7128e0e31baf63732fb5/)
+- [Vue 3模板引用的生命周期时机如何把握？常见陷阱该如何避免？](https://blog.cmdragon.cn/posts/7d2a0f6555ecbe92afd7d2491c427463/)
+- [Vue 3模板引用如何实现父组件与子组件的高效交互？](https://blog.cmdragon.cn/posts/3fb7bdd84128b7efaaa1c979e1f28dee/)
+- [Vue中为何需要模板引用？又如何高效实现DOM与组件实例的直接访问？](https://blog.cmdragon.cn/posts/23f3464ba16c7054b4783cded50c04c6/)
+
+</details>
+
+<details>
+<summary>免费好用的热门在线工具</summary>
+
+- [多直播聚合器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/multi-live-aggregator)
+- [Proto文件生成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/proto-file-generator)
+- [图片转粒子 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/image-to-particles)
+- [视频下载器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/video-downloader)
+- [文件格式转换器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/file-converter)
+- [M3U8在线播放器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/m3u8-player)
+- [快图设计 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/quick-image-design)
+- [高级文字转图片转换器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/text-to-image-advanced)
+- [RAID 计算器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/raid-calculator)
+- [在线PS - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/photoshop-online)
+- [Mermaid 在线编辑器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/mermaid-live-editor)
+- [数学求解计算器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/math-solver-calculator)
+- [智能提词器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/smart-teleprompter)
+- [魔法简历 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/magic-resume)
+- [Image Puzzle Tool - 图片拼图工具 | By cmdragon](https://tools.cmdragon.cn/zh/apps/image-puzzle-tool)
+- [字幕下载工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/subtitle-downloader)
+- [歌词生成工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/lyrics-generator)
+- [网盘资源聚合搜索 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/cloud-drive-search)
+- [ASCII字符画生成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/ascii-art-generator)
+- [JSON Web Tokens 工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/jwt-tool)
+- [Bcrypt 密码工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/bcrypt-tool)
+- [GIF 合成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/gif-composer)
+- [GIF 分解器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/gif-decomposer)
+- [文本隐写术 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/text-steganography)
+- [CMDragon 在线工具 - 高级AI工具箱与开发者套件 | 免费好用的在线工具](https://tools.cmdragon.cn/zh)
+- [应用商店 - 发现1000+提升效率与开发的AI工具和实用程序 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps?category=trending)
+- [CMDragon 更新日志 - 最新更新、功能与改进 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/changelog)
+- [支持我们 - 成为赞助者 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/sponsor)
+- [AI文本生成图像 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/text-to-image-ai)
+- [临时邮箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/temp-email)
+- [二维码解析器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/qrcode-parser)
+- [文本转思维导图 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/text-to-mindmap)
+- [正则表达式可视化工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/regex-visualizer)
+- [文件隐写工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/steganography-tool)
+- [IPTV 频道探索器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/iptv-explorer)
+- [快传 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/snapdrop)
+- [随机抽奖工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/lucky-draw)
+- [动漫场景查找器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/anime-scene-finder)
+- [时间工具箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/time-toolkit)
+- [网速测试 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/speed-test)
+- [AI 智能抠图工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/background-remover)
+- [背景替换工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/background-replacer)
+- [艺术二维码生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/artistic-qrcode)
+- [Open Graph 元标签生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/open-graph-generator)
+- [图像对比工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/image-comparison)
+- [图片压缩专业版 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/image-compressor)
+- [密码生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/password-generator)
+- [SVG优化器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/svg-optimizer)
+- [调色板生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/color-palette)
+- [在线节拍器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/online-metronome)
+- [IP归属地查询 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/ip-geolocation)
+- [CSS网格布局生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/css-grid-layout)
+- [邮箱验证工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/email-validator)
+- [书法练习字帖 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/calligraphy-practice)
+- [金融计算器套件 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/finance-calculator-suite)
+- [中国亲戚关系计算器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/chinese-kinship-calculator)
+- [Protocol Buffer 工具箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/protobuf-toolkit)
+- [IP归属地查询 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/ip-geolocation)
+- [图片无损放大 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/image-upscaler)
+- [文本比较工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/text-compare)
+- [IP批量查询工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/ip-batch-lookup)
+- [域名查询工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/domain-finder)
+- [DNS工具箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/dns-toolkit)
+- [网站图标生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/favicon-generator)
+- [XML Sitemap](https://tools.cmdragon.cn/sitemap_index.xml)
+
+</details>

--- a/content/posts/front_end/vue/嵌套元素、首次出现、key触发——Transition那些容易被忽略的细节.md
+++ b/content/posts/front_end/vue/嵌套元素、首次出现、key触发——Transition那些容易被忽略的细节.md
@@ -1,0 +1,828 @@
+---
+url: /posts/e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6/
+title: 嵌套元素、首次出现、key触发——Transition那些容易被忽略的细节
+date: 2026-05-31T14:00:00+08:00
+lastmod: 2026-05-31T14:00:00+08:00
+author: cmdragon
+cover: https://api2.cmdragon.cn/upload/cmder/images/2026年6月3日 21_48_28.png
+
+summary: Vue 3 Transition组件在使用中有不少容易忽略的细节：嵌套元素的过渡如何处理、duration属性怎么用、appear让元素首次渲染也有动画、key属性如何触发过渡。本文逐一拆解这些细节，帮你避开坑。
+
+categories:
+  - vue
+
+tags:
+  - 基础入门
+  - Transition
+  - 深层级过渡
+  - duration
+  - appear
+  - key属性
+  - 过渡细节
+---
+
+<img src="https://api2.cmdragon.cn/upload/cmder/images/2026年6月3日 21_48_28.png" title="cover.png" alt="cmdragon_cn.png"/>
+
+<img src="https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg" title="cmdragon_cn.png" alt="cmdragon_cn.png"/>
+
+扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`
+
+[发现1000+提升效率与开发的AI工具和实用程序](https://tools.cmdragon.cn/zh/apps?category=ai_chat)：https://tools.cmdragon.cn/zh/apps?category=ai_chat
+
+## 一、嵌套元素的过渡——子元素也想动怎么办
+
+上一篇咱们聊了Transition组件的6个CSS类名和基本用法，但你有没有想过一个问题：如果你的Transition里面包了一个div，这个div里面又套了一个div，那里面那个div能不能也有动画效果？
+
+答案是：能，但不是自动的，得你自己写CSS。
+
+### Transition只管直接子元素
+
+先说一个关键点：`<Transition>`组件添加的那些过渡类名（`v-enter-from`、`v-enter-active`之类的），只会加在它的**直接子元素**上。嵌套在里面的子元素，Vue不会自动给它们加类名。
+
+打个比方，Transition就像一个快递员，他只负责把包裹送到你家门口（直接子元素），至于包裹里面还有没有小盒子（嵌套子元素），他不管。小盒子要拆开，得你自己来。
+
+### 用CSS选择器让子元素也动起来
+
+虽然Vue不会自动给嵌套子元素加类名，但我们可以利用CSS的**后代选择器**来实现。原理很简单：当父元素被加上了`v-enter-active`之类的类名时，我们用`.v-enter-active .inner`这样的选择器，让子元素也跟着有过渡效果。
+
+来看一个完整的例子，外层div淡入，内层div滑入：
+
+```vue
+<template>
+  <!-- Transition包裹外层容器 -->
+  <Transition name="nested">
+    <!-- v-if控制整个区块的显示隐藏 -->
+    <div v-if="show" class="outer">
+      <!-- 内层嵌套元素，也会有自己的动画 -->
+      <div class="inner">我是内层元素，我会滑进来</div>
+    </div>
+  </Transition>
+  <!-- 按钮切换显示状态 -->
+  <button @click="show = !show">切换</button>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+// 控制元素是否显示
+const show = ref(false);
+</script>
+
+<style>
+/* 外层元素的进入和离开过渡 */
+.nested-enter-active,
+.nested-leave-active {
+  transition: all 0.3s ease-in-out;
+}
+
+/* 外层元素的进入起始状态和离开结束状态 */
+.nested-enter-from,
+.nested-leave-to {
+  opacity: 0;
+}
+
+/* 内层元素的过渡效果——用后代选择器选中 */
+.nested-enter-active .inner,
+.nested-leave-active .inner {
+  transition: all 0.3s ease-in-out;
+}
+
+/* 内层元素的进入起始状态：向右偏移30px且透明 */
+.nested-enter-from .inner,
+.nested-leave-to .inner {
+  transform: translateX(30px);
+  opacity: 0;
+}
+
+/* 外层容器样式 */
+.outer {
+  background: #42b883;
+  padding: 30px;
+  border-radius: 8px;
+  min-height: 100px;
+}
+
+/* 内层元素样式 */
+.inner {
+  background: #35495e;
+  color: white;
+  padding: 20px;
+  border-radius: 4px;
+}
+</style>
+```
+
+看到没？关键就是`.nested-enter-active .inner`和`.nested-enter-from .inner`这两组选择器。当外层元素被加上`nested-enter-active`类名时，内层的`.inner`元素也会被CSS选中，从而拥有自己的过渡效果。
+
+### 子元素过渡时长别超过父元素
+
+这里有个很重要的原则：**子元素的过渡时长不应该超过父元素的过渡时长**。为啥呢？你想啊，父元素0.3秒就淡入完成了，子元素0.5秒才滑完——这时候父元素已经完全显示了，子元素还在那慢慢悠悠地滑，看着就很别扭，而且可能导致过渡结束时机判断出问题。
+
+### 做个交错动画效果
+
+嵌套过渡有个很好玩的用法：给子元素加一个`transition-delay`，让子元素的动画比父元素晚一点开始，形成一种"交错进入"的效果，视觉上特别有层次感：
+
+```css
+/* 进入时内层元素延迟0.25秒再开始动画 */
+.nested-enter-active .inner {
+  transition-delay: 0.25s;
+}
+```
+
+就这么一行CSS，外层先淡入，0.25秒后内层再滑入，效果一下子就高级了。
+
+### 嵌套过渡的时间关系
+
+用流程图来看看嵌套过渡的时间线是怎么走的：
+
+```mermaid
+sequenceDiagram
+    participant Vue as Vue响应式系统
+    participant 外层 as 外层元素(.outer)
+    participant 内层 as 内层元素(.inner)
+
+    Note over Vue: show变为true
+    Vue->>外层: 添加 nested-enter-from + nested-enter-active
+    Vue->>内层: CSS选择器生效，.inner获得过渡样式
+    Note over 外层: 0s → 开始淡入(opacity: 0→1)
+    Note over 内层: 0s~0.25s → 等待(delay)
+    Note over 内层: 0.25s → 开始滑入(translateX: 30px→0)
+    Note over 外层: 0.3s → 外层淡入完成
+    Note over 内层: 0.55s → 内层滑入完成
+    Vue->>外层: 移除过渡类名，动画结束
+
+    Note over Vue: show变为false
+    Vue->>外层: 添加 nested-leave-from + nested-leave-active
+    Note over 外层: 0s → 开始淡出(opacity: 1→0)
+    Note over 内层: 0s → 开始滑出(translateX: 0→30px)
+    Note over 外层,内层: 0.3s → 过渡完成
+    Vue->>外层: 移除DOM
+```
+
+从这个时间线可以清楚地看到：外层先动，内层延迟后跟上。离开的时候两者同时开始。这就是嵌套过渡的基本节奏。
+
+## 二、duration属性——手动告诉Vue动画多长
+
+### Vue怎么知道动画啥时候结束？
+
+默认情况下，Vue会自动检测元素的CSS `transition-duration`或`animation-duration`来判断过渡啥时候结束。它监听的是`transitionend`或`animationend`事件——哪个先触发就认哪个。
+
+这就像你跟朋友说"等我一下"，然后朋友就盯着你看，等你动了他就知道你准备好了。Vue也是盯着DOM元素，等浏览器告诉它"动画播完了"，它就收工。
+
+### 啥时候Vue会判断失误？
+
+但有些情况下，Vue的自动检测会翻车：
+
+1. **嵌套元素的过渡**：就像上面说的，外层元素0.3秒就播完了，Vue监听到外层的`transitionend`事件就以为"哦，结束了"，但其实内层元素0.55秒才播完。结果Vue提前收工，内层动画被截断。
+
+2. **JavaScript动画**：如果你用GSAP、Anime.js这些库来做动画，Vue根本检测不到CSS的`transitionend`事件，因为压根就没有CSS过渡。
+
+3. **复杂的CSS动画组合**：一个元素上同时有transition和animation，Vue可能搞混该听哪个。
+
+### duration属性登场
+
+这时候就需要`duration`属性出马了。它的作用很简单：**手动告诉Vue过渡要多久**，别自己瞎猜。
+
+用法有两种：
+
+**方式一：统一时长**
+
+```vue
+<template>
+  <!-- 告诉Vue：整个过渡过程550毫秒 -->
+  <Transition :duration="550">
+    <div v-if="show" class="outer">
+      <div class="inner">嵌套元素</div>
+    </div>
+  </Transition>
+  <button @click="show = !show">切换</button>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+const show = ref(false);
+</script>
+
+<style>
+.outer {
+  background: #42b883;
+  padding: 30px;
+  border-radius: 8px;
+}
+
+.inner {
+  background: #35495e;
+  color: white;
+  padding: 20px;
+  border-radius: 4px;
+  transition: all 0.3s ease-in-out;
+}
+
+/* 外层淡入淡出 */
+.v-enter-active,
+.v-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
+}
+
+/* 内层滑入滑出，带0.25秒延迟 */
+.v-enter-active .inner {
+  transition: all 0.3s ease-in-out 0.25s;
+  transform: translateX(30px);
+  opacity: 0;
+}
+
+.v-enter-to .inner {
+  transform: translateX(0);
+  opacity: 1;
+}
+
+.v-leave-active .inner {
+  transition: all 0.3s ease-in-out;
+}
+
+.v-leave-to .inner {
+  transform: translateX(30px);
+  opacity: 0;
+}
+</style>
+```
+
+这里`duration`设为550，因为内层元素有0.25秒延迟+0.3秒动画=0.55秒，所以总时长就是550毫秒。
+
+**方式二：分别指定进入和离开时长**
+
+```vue
+<template>
+  <!-- 进入500毫秒，离开800毫秒 -->
+  <Transition :duration="{ enter: 500, leave: 800 }">
+    <div v-if="show" class="box">我有明确的时长</div>
+  </Transition>
+  <button @click="show = !show">切换</button>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+const show = ref(false);
+</script>
+
+<style>
+.box {
+  background: #42b883;
+  color: white;
+  padding: 30px;
+  border-radius: 8px;
+}
+
+.v-enter-active {
+  transition: all 0.5s ease;
+}
+
+.v-leave-active {
+  transition: all 0.8s ease;
+}
+
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
+  transform: translateY(20px);
+}
+</style>
+```
+
+对象形式的`duration`让你可以分别控制进入和离开的时长，更灵活。
+
+### duration的值怎么算？
+
+算duration其实不难，记住这个公式就行：
+
+> **总时长 = 最大延迟 + 最大动画时长**
+
+比如内层元素`transition-delay: 0.25s`，`transition-duration: 0.3s`，那总时长就是`250 + 300 = 550`毫秒。把所有嵌套元素的时长都算一遍，取最大的那个，就是duration该设的值。
+
+## 三、appear——首次渲染也要动画
+
+### 默认行为：首次渲染没动画
+
+你有没有注意过这个现象：页面刚加载的时候，Transition里面的元素直接就出现了，没有任何动画。但之后你切换显示/隐藏，动画就正常了。
+
+这是因为Transition默认只在元素的**插入**和**移除**时触发过渡动画。"首次渲染"虽然也是元素插入DOM的过程，但Vue默认不把它当作一次"过渡"来处理。
+
+打个比方，就像你新搬进一个房子，家具直接就摆好了（首次渲染），不会有搬家具的过程动画。但之后你把家具搬出去再搬回来，就有动画了。
+
+### appear属性：让首次渲染也有动画
+
+如果你希望元素首次渲染时也播一个进入动画，加上`appear`属性就行：
+
+```vue
+<template>
+  <!-- 加上appear，首次渲染也会触发进入动画 -->
+  <Transition appear>
+    <div class="box">我首次出现也会有动画哦</div>
+  </Transition>
+</template>
+
+<style>
+.v-enter-active,
+.v-leave-active {
+  transition: opacity 0.5s ease;
+}
+
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
+}
+
+.box {
+  background: #42b883;
+  color: white;
+  padding: 30px;
+  border-radius: 8px;
+}
+</style>
+```
+
+就这么简单，加一个`appear`，首次渲染时元素就会从透明(opacity: 0)淡入到完全显示(opacity: 1)。
+
+### appear的类名体系
+
+appear有自己的一套类名，结构和enter一模一样：
+
+| 类名              | 作用                 |
+| ----------------- | -------------------- |
+| `v-appear-from`   | 出现动画的起始状态   |
+| `v-appear-active` | 出现动画的进行中状态 |
+| `v-appear-to`     | 出现动画的结束状态   |
+
+如果你用了命名过渡（比如`name="fade"`），那类名就变成`fade-appear-from`、`fade-appear-active`、`fade-appear-to`。
+
+如果你没单独写appear的类名，Vue会**回退使用enter的类名**。也就是说，`v-appear-from`没写就用`v-enter-from`，`v-appear-active`没写就用`v-enter-active`，以此类推。所以大多数情况下，你加个`appear`属性就够了，不用额外写CSS。
+
+### appear的自定义类名
+
+和enter/leave一样，appear也支持自定义类名：
+
+- `appear-from-class`：自定义出现起始状态的类名
+- `appear-active-class`：自定义出现进行中状态的类名
+- `appear-to-class`：自定义出现结束状态的类名
+
+来看一个完整示例，appear动画和enter动画用不同的效果：
+
+```vue
+<template>
+  <!-- appear让首次渲染也有动画，自定义appear的类名 -->
+  <Transition
+    appear
+    appear-from-class="custom-appear-from"
+    appear-active-class="custom-appear-active"
+    appear-to-class="custom-appear-to"
+    name="slide"
+  >
+    <div v-if="show" class="box">
+      我首次出现会从下方弹上来，之后切换会左右滑动
+    </div>
+  </Transition>
+  <button @click="show = !show">切换</button>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+const show = ref(true);
+</script>
+
+<style>
+.box {
+  background: #42b883;
+  color: white;
+  padding: 30px;
+  border-radius: 8px;
+  margin-top: 20px;
+}
+
+/* 自定义appear动画：从下方弹上来 */
+.custom-appear-from {
+  opacity: 0;
+  transform: translateY(50px);
+}
+
+.custom-appear-active {
+  transition: all 0.6s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.custom-appear-to {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* 正常的enter/leave动画：左右滑动 */
+.slide-enter-active {
+  transition: all 0.3s ease-out;
+}
+
+.slide-leave-active {
+  transition: all 0.5s cubic-bezier(1, 0.5, 0.8, 1);
+}
+
+.slide-enter-from,
+.slide-leave-to {
+  transform: translateX(20px);
+  opacity: 0;
+}
+</style>
+```
+
+这个例子中，首次出现时元素从下方弹上来（有个弹性曲线），之后切换显示隐藏时则是左右滑动。两种不同的动画效果，各司其职。
+
+## 四、key属性——不换元素也能触发过渡
+
+### 正常情况下过渡怎么触发？
+
+前面咱们说的过渡，都是靠`v-if`、`v-show`或者动态组件来触发的。核心逻辑是：元素从"不存在"变成"存在"（进入过渡），或者从"存在"变成"不存在"（离开过渡）。
+
+但有时候你会遇到一种情况：**元素一直存在，只是内容变了，你也想加个过渡动画**。比如一个展示用户信息的卡片，切换不同用户时，卡片本身没变，只是里面的文字换了。这时候用`v-if`是不行的，因为元素一直都在。
+
+### key属性触发过渡的原理
+
+Vue的Transition组件支持通过改变`key`属性来触发过渡。原理是这样的：
+
+当你给Transition里面的元素设置了`key`属性，Vue会根据`key`的值来判断这是不是"同一个元素"。如果`key`变了，Vue就认为旧元素"离开"了、新元素"进入"了，即使它们其实是同一种元素。
+
+这就像换身份证——虽然人还是那个人，但身份证号变了，系统就认为是"新的人"了。key就是元素的"身份证号"。
+
+来看个例子：
+
+```vue
+<template>
+  <div>
+    <!-- 按钮组：切换不同的用户 -->
+    <button
+      v-for="user in users"
+      :key="user.id"
+      @click="currentId = user.id"
+      :class="{ active: currentId === user.id }"
+    >
+      {{ user.name }}
+    </button>
+
+    <!-- 用key触发过渡：currentId变了，过渡就触发 -->
+    <Transition name="fade" mode="out-in">
+      <!-- key绑定currentId，值变了就触发过渡 -->
+      <div :key="currentId" class="user-card">
+        <h3>{{ currentUser.name }}</h3>
+        <p>{{ currentUser.email }}</p>
+        <p>{{ currentUser.role }}</p>
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from "vue";
+
+// 用户列表数据
+const users = [
+  { id: 1, name: "张三", email: "zhangsan@example.com", role: "前端开发" },
+  { id: 2, name: "李四", email: "lisi@example.com", role: "后端开发" },
+  { id: 3, name: "王五", email: "wangwu@example.com", role: "UI设计" },
+];
+
+// 当前选中的用户ID
+const currentId = ref(1);
+
+// 计算属性：根据ID找到当前用户
+const currentUser = computed(() => {
+  return users.find((user) => user.id === currentId.value) || users[0];
+});
+</script>
+
+<style>
+/* 按钮样式 */
+button {
+  margin-right: 10px;
+  padding: 8px 16px;
+  border: 2px solid #42b883;
+  border-radius: 4px;
+  background: white;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+button.active {
+  background: #42b883;
+  color: white;
+}
+
+button:hover {
+  opacity: 0.8;
+}
+
+/* 用户卡片样式 */
+.user-card {
+  margin-top: 20px;
+  padding: 20px;
+  background: #f5f5f5;
+  border-radius: 8px;
+  border-left: 4px solid #42b883;
+}
+
+/* 淡入淡出过渡 */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>
+```
+
+注意这里用了`mode="out-in"`，意思是旧元素先离开，新元素再进入。如果不用mode，两个元素会同时存在，可能会出现布局跳动的问题。
+
+### key触发的典型场景
+
+key触发过渡特别适合这些场景：
+
+1. **同组件不同数据切换**：就像上面的用户卡片，组件结构不变，只是数据变了
+2. **路由视图过渡**：不同路由对应同一个组件，但参数不同
+3. **步骤指示器**：当前步骤变了，显示区域需要过渡
+4. **图片轮播**：同一位置切换不同图片
+
+### key触发机制流程图
+
+用流程图来看看key触发过渡的完整过程：
+
+```mermaid
+flowchart TD
+    A[用户操作：切换用户] --> B[currentId的值发生变化]
+    B --> C{Vue检测到key值变了}
+    C --> D[Vue认为旧key元素要"离开"]
+    C --> E[Vue认为新key元素要"进入"]
+    D --> F[添加 leave-from + leave-active 类名]
+    E --> G[等待旧元素离开完成]
+    F --> H[触发transitionend事件]
+    H --> G
+    G --> I[添加 enter-from + enter-active 类名]
+    I --> J[新元素开始进入动画]
+    J --> K[触发transitionend事件]
+    K --> L[移除过渡类名，过渡完成]
+
+    style A fill:#42b883,color:#fff
+    style C fill:#35495e,color:#fff
+    style L fill:#42b883,color:#fff
+```
+
+从这个流程图可以看出，key变了之后，Vue的处理流程和`v-if`切换是一模一样的。只不过触发条件从"元素是否存在"变成了"key值是否改变"。
+
+### key和v-if的区别
+
+| 对比项           | v-if                           | key                               |
+| ---------------- | ------------------------------ | --------------------------------- |
+| 触发条件         | 条件为true/false               | key值发生变化                     |
+| 元素是否销毁重建 | 是，条件为false时元素从DOM移除 | 是，key变了旧元素移除、新元素创建 |
+| 适用场景         | 元素确实需要显示/隐藏          | 元素一直存在但内容需要切换        |
+| 是否需要mode     | 多元素时需要                   | 通常配合out-in使用                |
+
+说白了，key触发过渡的本质就是：**让Vue误以为换了一个新元素**，从而触发完整的进入/离开过渡流程。这招在组件内容切换时特别好用。
+
+---
+
+## 课后 Quiz
+
+### 问题一
+
+你在用Transition包裹一个嵌套结构，外层div淡入0.3秒，内层div有0.25秒延迟+0.3秒动画。如果不设duration属性，会发生什么？
+
+**答案解析**：
+
+Vue默认监听的是**根元素**（也就是外层div）的`transitionend`事件。外层div的过渡0.3秒就结束了，Vue听到`transitionend`就认为整个过渡完成了，于是移除过渡类名。但此时内层div的动画才刚开始0.05秒（0.3 - 0.25 = 0.05），还没播完就被强制中断了。
+
+解决办法就是加上`:duration="550"`（250 + 300 = 550毫秒），手动告诉Vue等够550毫秒再收工。这样内层动画就能完整播放了。
+
+### 问题二
+
+appear属性和v-if的enter过渡有什么区别？如果我只加了appear但没写appear相关的CSS类名，会怎样？
+
+**答案解析**：
+
+两者的触发时机不同：
+
+- `appear`是在**组件首次渲染**时触发，只触发一次
+- `enter`是在元素每次**从DOM插入**时触发，可以触发多次
+
+如果你加了`appear`但没写`v-appear-from`、`v-appear-active`、`v-appear-to`这些CSS类名，Vue会**回退使用enter的类名**。也就是说，`v-appear-from`没找到就用`v-enter-from`，`v-appear-active`没找到就用`v-enter-active`，以此类推。
+
+所以大多数情况下，你只需要加个`appear`属性，不用额外写CSS，首次渲染的动画效果和后续的enter动画效果是一样的。只有当你需要首次出现和后续进入用不同动画时，才需要单独写appear的类名。
+
+### 问题三
+
+下面的代码中，切换按钮时会有过渡动画吗？为什么？
+
+```vue
+<Transition name="fade">
+  <div :class="{ active: isActive }">内容</div>
+</Transition>
+```
+
+**答案解析**：
+
+**不会有过渡动画**。因为Transition组件触发过渡的条件是：元素被插入DOM或从DOM移除。这里`div`一直存在于DOM中，只是`class`在变化。`class`的变化不会触发Transition的过渡流程。
+
+要让这个场景有过渡效果，有两种方式：
+
+1. **用key属性**：给div加`:key="isActive"`，当`isActive`变化时key也变了，Transition就会触发过渡
+2. **用v-if/v-show**：把条件渲染改成`v-if="isActive"`或`v-show="isActive"`
+
+方式一适合元素内容也需要跟着变的场景，方式二适合元素确实需要显示/隐藏的场景。
+
+---
+
+## 常见报错解决方案
+
+### 报错一：嵌套过渡动画被截断，内层元素动画没播完就停了
+
+**产生原因**：
+
+Vue默认监听根元素的`transitionend`事件来判断过渡结束。嵌套元素的动画时长如果超过根元素，根元素先播完，Vue就提前移除了过渡类名，导致内层动画被截断。
+
+**解决方案**：
+
+使用`duration`属性手动指定过渡总时长。计算方式是所有嵌套元素中最大的"延迟+动画时长"：
+
+```vue
+<!-- 内层有0.25s延迟 + 0.3s动画 = 0.55s -->
+<Transition :duration="550">
+  <div v-if="show" class="outer">
+    <div class="inner">内容</div>
+  </div>
+</Transition>
+```
+
+**预防建议**：
+
+写嵌套过渡时，养成习惯先算好总时长再设duration。也可以把内层动画时长控制在和外层一样，或者比外层更短，这样就不需要额外设duration了。
+
+### 报错二：加了appear但首次渲染没有动画
+
+**产生原因**：
+
+最常见的原因是CSS类名写错了。比如你用了命名过渡`<Transition name="slide" appear>`，但CSS里写的是`v-appear-from`而不是`slide-appear-from`。命名过渡的appear类名前缀要和name一致。
+
+**解决方案**：
+
+检查CSS类名前缀是否和Transition的name属性匹配：
+
+```vue
+<!-- 命名过渡 -->
+<Transition name="slide" appear>
+  <div>内容</div>
+</Transition>
+```
+
+```css
+/* 正确：前缀是slide */
+.slide-appear-from {
+  opacity: 0;
+}
+.slide-appear-active {
+  transition: opacity 0.5s ease;
+}
+.slide-appear-to {
+  opacity: 1;
+}
+
+/* 错误：前缀是v，和name不匹配 */
+/* .v-appear-from { ... } */
+```
+
+**预防建议**：
+
+如果appear和enter用同样的动画效果，可以不写appear的类名，Vue会自动回退使用enter的类名。这样既省代码又不容易写错。
+
+### 报错三：key触发过渡时两个元素同时出现，布局跳动
+
+**产生原因**：
+
+Transition默认行为是：旧元素离开和新元素进入**同时进行**。当key变化时，旧元素还没完全消失，新元素就已经插入了，两个元素同时占据空间，导致布局跳动。
+
+**解决方案**：
+
+加上`mode`属性，指定过渡模式。最常用的是`mode="out-in"`，让旧元素先离开，新元素再进入：
+
+```vue
+<Transition name="fade" mode="out-in">
+  <div :key="currentId">内容</div>
+</Transition>
+```
+
+另一种模式是`mode="in-out"`，新元素先进入，旧元素再离开。不过这种模式用得比较少，因为两个元素会短暂重叠。
+
+**预防建议**：
+
+凡是使用key触发过渡的场景，基本都应该加`mode="out-in"`。除非你有特殊的视觉需求（比如两个元素重叠的交叉淡入淡出效果），否则out-in是最稳妥的选择。
+
+---
+
+参考链接：https://vuejs.org/guide/built-ins/transition.html
+
+余下文章内容请点击跳转至 个人博客页面 或者 扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`，阅读完整的文章：[嵌套元素、首次出现、key触发——Transition那些容易被忽略的细节](https://blog.cmdragon.cn/posts/e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6/)
+
+<details>
+<summary>往期文章归档</summary>
+
+- [Vue 3 静态与动态 Props 如何传递？TypeScript 类型约束有何必要？](https://blog.cmdragon.cn/posts/94ab48753b64780ca3ab7a7115ae8522/)
+- [Vue 3中组件局部注册的优势与实现方式如何？](https://blog.cmdragon.cn/posts/dbf576e744870f6de26fd8a2e03e47da/)
+- [如何在Vue3中优化生命周期钩子性能并规避常见陷阱？](https://blog.cmdragon.cn/posts/12d98b3b9ccd6c19a1b169d720ac5c80/)
+- [Vue 3 Composition API生命周期钩子：如何实现从基础理解到高阶复用？](https://blog.cmdragon.cn/posts/8884e2b70287fcb263c57648eeb27419/)
+- [Vue 3生命周期钩子实战指南：如何正确选择onMounted、onUpdated与onUnmounted的应用场景？](https://blog.cmdragon.cn/posts/883c6dbc50ae4183770a4462e0b8ae4d/)
+- [Vue 3中生命周期钩子与响应式系统如何实现协同工作？](https://blog.cmdragon.cn/posts/70dad360ffa9dce14d0d69611b8cb019/)
+- [Vue 3组件生命周期钩子的执行顺序与使用场景是什么？](https://blog.cmdragon.cn/posts/db44294a78dc9f666f67b053f6c83567/)
+- [Vue组件全局注册与局部注册如何抉择？](https://blog.cmdragon.cn/posts/43ead630ea17da65d99ad2eb8188e472/)
+- [Vue3组件化开发中，Props与Emits如何实现数据流转与事件协作？](https://blog.cmdragon.cn/posts/8cff7d2df113da66ea7be560c4d1d22a/)
+- [Vue 3模板引用如何与其他特性协同实现复杂交互？](https://blog.cmdragon.cn/posts/331bf75d114ab09116eadfcdca602b58/)
+- [Vue 3 v-for中模板引用如何实现高效管理与动态控制？](https://blog.cmdragon.cn/posts/cb380897ddc3578b180ecf8843c774c1/)
+- [Vue 3的defineExpose：如何突破script setup组件默认封装，实现精准的父子通讯？](https://blog.cmdragon.cn/posts/202ae0f4acde7128e0e31baf63732fb5/)
+- [Vue 3模板引用的生命周期时机如何把握？常见陷阱该如何避免？](https://blog.cmdragon.cn/posts/7d2a0f6555ecbe92afd7d2491c427463/)
+- [Vue 3模板引用如何实现父组件与子组件的高效交互？](https://blog.cmdragon.cn/posts/3fb7bdd84128b7efaaa1c979e1f28dee/)
+- [Vue中为何需要模板引用？又如何高效实现DOM与组件实例的直接访问？](https://blog.cmdragon.cn/posts/23f3464ba16c7054b4783cded50c04c6/)
+
+</details>
+
+<details>
+<summary>免费好用的热门在线工具</summary>
+
+- [多直播聚合器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/multi-live-aggregator)
+- [Proto文件生成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/proto-file-generator)
+- [图片转粒子 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/image-to-particles)
+- [视频下载器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/video-downloader)
+- [文件格式转换器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/file-converter)
+- [M3U8在线播放器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/m3u8-player)
+- [快图设计 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/quick-image-design)
+- [高级文字转图片转换器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/text-to-image-advanced)
+- [RAID 计算器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/raid-calculator)
+- [在线PS - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/photoshop-online)
+- [Mermaid 在线编辑器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/mermaid-live-editor)
+- [数学求解计算器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/math-solver-calculator)
+- [智能提词器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/smart-teleprompter)
+- [魔法简历 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/magic-resume)
+- [Image Puzzle Tool - 图片拼图工具 | By cmdragon](https://tools.cmdragon.cn/zh/apps/image-puzzle-tool)
+- [字幕下载工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/subtitle-downloader)
+- [歌词生成工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/lyrics-generator)
+- [网盘资源聚合搜索 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/cloud-drive-search)
+- [ASCII字符画生成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/ascii-art-generator)
+- [JSON Web Tokens 工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/jwt-tool)
+- [Bcrypt 密码工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/bcrypt-tool)
+- [GIF 合成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/gif-composer)
+- [GIF 分解器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/gif-decomposer)
+- [文本隐写术 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/text-steganography)
+- [CMDragon 在线工具 - 高级AI工具箱与开发者套件 | 免费好用的在线工具](https://tools.cmdragon.cn/zh)
+- [应用商店 - 发现1000+提升效率与开发的AI工具和实用程序 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps?category=trending)
+- [CMDragon 更新日志 - 最新更新、功能与改进 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/changelog)
+- [支持我们 - 成为赞助者 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/sponsor)
+- [AI文本生成图像 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/text-to-image-ai)
+- [临时邮箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/temp-email)
+- [二维码解析器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/qrcode-parser)
+- [文本转思维导图 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/text-to-mindmap)
+- [正则表达式可视化工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/regex-visualizer)
+- [文件隐写工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/steganography-tool)
+- [IPTV 频道探索器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/iptv-explorer)
+- [快传 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/snapdrop)
+- [随机抽奖工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/lucky-draw)
+- [动漫场景查找器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/anime-scene-finder)
+- [时间工具箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/time-toolkit)
+- [网速测试 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/speed-test)
+- [AI 智能抠图工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/background-remover)
+- [背景替换工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/background-replacer)
+- [艺术二维码生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/artistic-qrcode)
+- [Open Graph 元标签生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/open-graph-generator)
+- [图像对比工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/image-comparison)
+- [图片压缩专业版 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/image-compressor)
+- [密码生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/password-generator)
+- [SVG优化器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/svg-optimizer)
+- [调色板生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/color-palette)
+- [在线节拍器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/online-metronome)
+- [IP归属地查询 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/ip-geolocation)
+- [CSS网格布局生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/css-grid-layout)
+- [邮箱验证工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/email-validator)
+- [书法练习字帖 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/calligraphy-practice)
+- [金融计算器套件 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/finance-calculator-suite)
+- [中国亲戚关系计算器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/chinese-kinship-calculator)
+- [Protocol Buffer 工具箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/protobuf-toolkit)
+- [IP归属地查询 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/ip-geolocation)
+- [图片无损放大 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/image-upscaler)
+- [文本比较工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/text-compare)
+- [IP批量查询工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/ip-batch-lookup)
+- [域名查询工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/domain-finder)
+- [DNS工具箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/dns-toolkit)
+- [网站图标生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/favicon-generator)
+- [XML Sitemap](https://tools.cmdragon.cn/sitemap_index.xml)
+
+</details>

--- a/content/posts/front_end/vue/把Transition包成组件复用，还能动态切换动画效果.md
+++ b/content/posts/front_end/vue/把Transition包成组件复用，还能动态切换动画效果.md
@@ -1,0 +1,1060 @@
+---
+url: /posts/f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7/
+title: 把Transition包成组件复用，还能动态切换动画效果
+date: 2026-05-31T15:00:00+08:00
+lastmod: 2026-05-31T15:00:00+08:00
+author: cmdragon
+cover: https://api2.cmdragon.cn/upload/cmder/images/2026年6月3日 21_57_41.png
+
+summary: Vue 3 Transition组件可以封装成独立组件实现复用，也可以通过动态name和动态props实现运行时切换动画效果。本文讲解如何用插槽封装可复用Transition组件、动态过渡的实现方式、以及TransitionGroup组件的基本用法。
+
+categories:
+  - vue
+
+tags:
+  - 基础入门
+  - Transition
+  - 可复用过渡
+  - 动态过渡
+  - 组件封装
+  - TransitionGroup
+  - 动画复用
+---
+
+<img src="https://api2.cmdragon.cn/upload/cmder/images/2026年6月3日 21_57_41.png" title="cover.png" alt="cmdragon_cn.png"/>
+
+<img src="https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg" title="cmdragon_cn.png" alt="cmdragon_cn.png"/>
+
+扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`
+
+[发现1000+提升效率与开发的AI工具和实用程序](https://tools.cmdragon.cn/zh/apps?category=ai_chat)：https://tools.cmdragon.cn/zh/apps?category=ai_chat
+
+## 一、为啥要封装Transition？
+
+上回咱们聊了Transition组件的6个CSS类名和基本用法，应该已经能写出像模像样的进出动画了。但有个问题你肯定很快就会碰到——同一个项目里，好几个地方都要用一模一样的过渡效果。
+
+比如你写了一个淡入淡出的弹窗动画，CSS类名写好了，时长配好了，缓动函数也调舒服了。结果产品经理说"侧边栏也要这个效果"、"下拉菜单也要这个效果"、"标签页切换也要这个效果"……你总不能每个地方都把那几行CSS和Transition配置再抄一遍吧？抄两遍还行，抄十遍你自己都想打自己。
+
+这就好比你在家里经常需要拧螺丝，每次都去工具箱里翻螺丝刀，翻到之后用完随手一扔，下次又要翻。聪明人的做法是啥？把螺丝刀固定放在一个位置，随用随取。封装Transition组件也是这个道理——把过渡效果"打包"成一个独立组件，哪里需要往哪里搬，改一处全局生效。
+
+封装Transition的好处总结一下：
+
+- **不用重复写CSS**：过渡样式定义一次，到处引用
+- **改一处全局生效**：产品说"动画改慢一点"，改一个组件就行，不用满项目找
+- **团队协作更方便**：别人用你的组件不用关心动画细节，直接用就完事
+- **代码更干净**：业务组件里不会堆一堆过渡相关的CSS
+
+那具体咋封装呢？往下看。
+
+## 二、用插槽封装可复用Transition组件
+
+### 基本封装思路
+
+封装Transition组件的核心思路特别简单：把`<Transition>`和它对应的CSS样式放在一个独立的`.vue`文件里，然后用`<slot>`把子内容"接"进来。这样外面用的时候，只需要把想要动画的内容塞进去就行。
+
+先看个流程图，把封装思路理一理：
+
+```mermaid
+flowchart TD
+    A[创建MyTransition.vue组件] --> B[在组件中写Transition标签]
+    B --> C[用slot接收子内容]
+    C --> D[在组件中定义过渡CSS样式]
+    D --> E[在其他组件中导入MyTransition]
+    E --> F[把需要动画的内容放进MyTransition标签里]
+    F --> G[动画效果自动生效]
+```
+
+说白了就是三步：建组件、放slot、写样式。下面直接上代码。
+
+### MyTransition组件代码
+
+先创建`MyTransition.vue`：
+
+```vue
+<!-- MyTransition.vue - 可复用的淡入淡出过渡组件 -->
+<template>
+  <!-- Transition组件，name设为my-transition -->
+  <!-- duration可以控制过渡时长，这里先写死，后面会改成props -->
+  <Transition name="my-transition">
+    <!-- 用slot把父组件传进来的子内容渲染出来 -->
+    <slot></slot>
+  </Transition>
+</template>
+
+<script setup>
+// 目前不需要任何JS逻辑
+// 过渡效果完全由CSS控制
+</script>
+
+<style scoped>
+/* 进入动画的活跃状态：定义过渡属性和时长 */
+.my-transition-enter-active {
+  transition:
+    opacity 0.5s ease,
+    transform 0.5s ease;
+}
+
+/* 离开动画的活跃状态：和进入一样的过渡配置 */
+.my-transition-leave-active {
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease;
+}
+
+/* 进入的起始状态：透明 + 向下偏移20px */
+.my-transition-enter-from {
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+/* 离开的结束状态：透明 + 向下偏移20px */
+.my-transition-leave-to {
+  opacity: 0;
+  transform: translateY(20px);
+}
+</style>
+```
+
+你看，这个组件做的事情就是：定义了一个名叫`my-transition`的过渡效果，包含淡入淡出+轻微上下移动的动画。所有CSS都封装在组件内部，外面完全不用管。
+
+### 使用MyTransition组件
+
+在别的组件里用起来特别简单：
+
+```vue
+<!-- App.vue - 使用可复用的MyTransition组件 -->
+<template>
+  <div class="app">
+    <!-- 切换按钮 -->
+    <button @click="show = !show">切换显示</button>
+
+    <!-- 用MyTransition包裹需要动画的元素 -->
+    <MyTransition>
+      <div v-if="show" class="box">我是被动画包裹的内容</div>
+    </MyTransition>
+
+    <!-- 同一个动画效果，另一个地方也能用 -->
+    <MyTransition>
+      <p v-if="show" class="text">这段文字也有一样的动画</p>
+    </MyTransition>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+// 导入封装好的MyTransition组件
+import MyTransition from "./MyTransition.vue";
+
+// 控制显示/隐藏
+const show = ref(true);
+</script>
+
+<style>
+.box {
+  width: 200px;
+  height: 200px;
+  background: #42b883;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  margin-top: 20px;
+}
+
+.text {
+  margin-top: 10px;
+  color: #333;
+  font-size: 16px;
+}
+</style>
+```
+
+就这么简单！导入组件、包上去、完事。以后产品说"动画改成0.8秒"，你只需要去`MyTransition.vue`里改一个数字，所有用到这个组件的地方自动更新。
+
+不过你可能已经发现了——现在这个组件的动画参数是写死的，时长0.5秒、偏移20px，都没法改。要是有的地方想慢一点、有的地方想快一点咋办？这就需要给组件加props了。
+
+## 三、带props的可复用Transition
+
+### 让过渡参数可配置
+
+给MyTransition加上props，让外部可以控制过渡时长、延迟、缓动函数这些参数。这样同一个组件，传不同的props就能有不同的效果。
+
+```vue
+<!-- MyTransition.vue - 带props的可复用过渡组件 -->
+<template>
+  <!-- 通过v-bind把props传给Transition -->
+  <!-- name、duration、mode等属性都可以动态绑定 -->
+  <Transition :name="name" :duration="duration" :mode="mode">
+    <slot></slot>
+  </Transition>
+</template>
+
+<script setup>
+// 定义props，让外部可以控制过渡参数
+defineProps({
+  // 过渡名称，决定CSS类名前缀，默认my-transition
+  name: {
+    type: String,
+    default: "my-transition",
+  },
+  // 过渡持续时间（毫秒），可以是一个数字或对象{ enter: number, leave: number }
+  duration: {
+    type: [Number, Object],
+    default: undefined,
+  },
+  // 过渡模式：out-in（先出后进）、in-out（先进后出）、默认（同时）
+  mode: {
+    type: String,
+    default: undefined,
+  },
+  // 进入动画时长（秒），用于CSS变量
+  enterDuration: {
+    type: Number,
+    default: 0.5,
+  },
+  // 离开动画时长（秒），用于CSS变量
+  leaveDuration: {
+    type: Number,
+    default: 0.3,
+  },
+  // 缓动函数
+  easing: {
+    type: String,
+    default: "ease",
+  },
+  // 进入时的偏移距离（px）
+  offset: {
+    type: Number,
+    default: 20,
+  },
+});
+</script>
+
+<style scoped>
+/* 用CSS自定义属性（变量）来接收props的值 */
+/* 这样CSS里的时长、偏移量等都可以动态控制 */
+.my-transition-enter-active {
+  transition:
+    opacity var(--enter-duration) var(--easing),
+    transform var(--enter-duration) var(--easing);
+}
+
+.my-transition-leave-active {
+  transition:
+    opacity var(--leave-duration) var(--easing),
+    transform var(--leave-duration) var(--easing);
+}
+
+.my-transition-enter-from {
+  opacity: 0;
+  transform: translateY(var(--offset));
+}
+
+.my-transition-leave-to {
+  opacity: 0;
+  transform: translateY(var(--offset));
+}
+</style>
+```
+
+等一下，上面的代码有个问题——CSS自定义属性不能直接从Vue的props传进去。我们需要用`v-bind`在`<style>`里绑定，或者换一种方式。Vue 3的`<style>`标签支持`v-bind()`函数来绑定响应式数据，但这里props不是响应式的CSS变量。
+
+更好的做法是通过Transition的内联样式或者用计算属性来动态生成CSS变量。咱们换一个方案——直接在模板上绑定style：
+
+```vue
+<!-- MyTransition.vue - 用CSS变量+内联style实现动态props -->
+<template>
+  <!-- 根元素上绑定CSS变量，这样子元素都能继承 -->
+  <div
+    class="my-transition-wrapper"
+    :style="{
+      '--enter-duration': enterDuration + 's',
+      '--leave-duration': leaveDuration + 's',
+      '--easing': easing,
+      '--offset': offset + 'px',
+    }"
+  >
+    <Transition :name="name" :duration="duration" :mode="mode">
+      <slot></slot>
+    </Transition>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  name: {
+    type: String,
+    default: "my-transition",
+  },
+  duration: {
+    type: [Number, Object],
+    default: undefined,
+  },
+  mode: {
+    type: String,
+    default: undefined,
+  },
+  enterDuration: {
+    type: Number,
+    default: 0.5,
+  },
+  leaveDuration: {
+    type: Number,
+    default: 0.3,
+  },
+  easing: {
+    type: String,
+    default: "ease",
+  },
+  offset: {
+    type: Number,
+    default: 20,
+  },
+});
+</script>
+
+<style scoped>
+/* CSS变量从父元素的style中继承 */
+.my-transition-enter-active {
+  transition:
+    opacity var(--enter-duration) var(--easing),
+    transform var(--enter-duration) var(--easing);
+}
+
+.my-transition-leave-active {
+  transition:
+    opacity var(--leave-duration) var(--easing),
+    transform var(--leave-duration) var(--easing);
+}
+
+.my-transition-enter-from {
+  opacity: 0;
+  transform: translateY(var(--offset));
+}
+
+.my-transition-leave-to {
+  opacity: 0;
+  transform: translateY(var(--offset));
+}
+</style>
+```
+
+不过这个方案有个小瑕疵——外层多了一个`<div>`包裹。如果你介意这个额外的DOM节点，可以用Vue 3的`v-bind()` in CSS语法，这是最优雅的方案：
+
+```vue
+<!-- MyTransition.vue - 最优雅的方案：v-bind() in CSS -->
+<template>
+  <Transition :name="name" :duration="duration" :mode="mode">
+    <slot></slot>
+  </Transition>
+</template>
+
+<script setup>
+const props = defineProps({
+  name: {
+    type: String,
+    default: "my-transition",
+  },
+  duration: {
+    type: [Number, Object],
+    default: undefined,
+  },
+  mode: {
+    type: String,
+    default: undefined,
+  },
+  enterDuration: {
+    type: Number,
+    default: 0.5,
+  },
+  leaveDuration: {
+    type: Number,
+    default: 0.3,
+  },
+  easing: {
+    type: String,
+    default: "ease",
+  },
+  offset: {
+    type: Number,
+    default: 20,
+  },
+});
+</script>
+
+<style scoped>
+/* Vue 3的v-bind()可以直接在CSS中绑定组件的响应式数据 */
+.my-transition-enter-active {
+  transition:
+    opacity v-bind('props.enterDuration + "s"') v-bind("props.easing"),
+    transform v-bind('props.enterDuration + "s"') v-bind("props.easing");
+}
+
+.my-transition-leave-active {
+  transition:
+    opacity v-bind('props.leaveDuration + "s"') v-bind("props.easing"),
+    transform v-bind('props.leaveDuration + "s"') v-bind("props.easing");
+}
+
+.my-transition-enter-from {
+  opacity: 0;
+  transform: translateY(v-bind('props.offset + "px"'));
+}
+
+.my-transition-leave-to {
+  opacity: 0;
+  transform: translateY(v-bind('props.offset + "px"'));
+}
+</style>
+```
+
+`v-bind()` in CSS 是Vue 3.2+引入的特性，它会在运行时把组件的响应式数据注入到CSS中。这样既没有多余的DOM节点，又能动态控制样式参数，简直完美。
+
+### 不同场景传不同props
+
+现在你可以在不同场景下用同一个组件，但传不同的参数：
+
+```vue
+<!-- 不同场景使用带props的MyTransition -->
+<template>
+  <div>
+    <!-- 弹窗：慢速淡入淡出，偏移大 -->
+    <MyTransition
+      :enter-duration="0.8"
+      :leave-duration="0.5"
+      :offset="40"
+      easing="cubic-bezier(0.4, 0, 0.2, 1)"
+    >
+      <div v-if="showModal" class="modal">弹窗内容</div>
+    </MyTransition>
+
+    <!-- 提示条：快速出现消失，偏移小 -->
+    <MyTransition :enter-duration="0.3" :leave-duration="0.2" :offset="10">
+      <div v-if="showToast" class="toast">操作成功</div>
+    </MyTransition>
+
+    <!-- 侧边栏：中等速度，从左滑入 -->
+    <MyTransition name="slide" :enter-duration="0.4" :leave-duration="0.3">
+      <div v-if="showSidebar" class="sidebar">侧边栏内容</div>
+    </MyTransition>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import MyTransition from "./MyTransition.vue";
+
+const showModal = ref(false);
+const showToast = ref(false);
+const showSidebar = ref(false);
+</script>
+```
+
+一个组件，三种效果，全靠props控制。这就是封装的威力。
+
+## 四、动态过渡——运行时切换动画
+
+### 动态name属性
+
+前面封装的组件虽然能通过props配置参数，但动画的"类型"（淡入淡出、滑动、弹跳……）还是由CSS类名决定的。那如果我想在运行时切换动画类型呢？比如用户点个按钮，动画从"淡入淡出"变成"弹跳"？
+
+Transition组件的`name`属性是可以动态绑定的。`:name="transitionName"`，只要`transitionName`的值变了，对应的CSS类名前缀就变了，动画效果自然就跟着变了。
+
+```mermaid
+flowchart TD
+    A[用户点击切换按钮] --> B[修改transitionName的值]
+    B --> C{transitionName等于啥？}
+    C -->|fade| D[使用.fade-enter-active等CSS类]
+    C -->|slide| E[使用.slide-enter-active等CSS类]
+    C -->|bounce| F[使用.bounce-enter-active等CSS类]
+    D --> G[执行淡入淡出动画]
+    E --> H[执行滑动动画]
+    F --> I[执行弹跳动画]
+```
+
+这个流程图说的很清楚：name变了，CSS类名前缀就变了，动画效果就切换了。
+
+### 完整代码示例：动态切换三种动画
+
+```vue
+<!-- DynamicTransition.vue - 动态切换过渡效果 -->
+<template>
+  <div class="demo">
+    <!-- 三个按钮，切换不同的过渡名称 -->
+    <div class="controls">
+      <button
+        v-for="item in transitions"
+        :key="item.name"
+        :class="{ active: currentTransition === item.name }"
+        @click="currentTransition = item.name"
+      >
+        {{ item.label }}
+      </button>
+    </div>
+
+    <!-- 动态绑定name属性 -->
+    <Transition :name="currentTransition" mode="out-in">
+      <!-- key很重要！让Vue知道这是不同的元素，需要触发过渡 -->
+      <div :key="currentTransition" class="box">
+        当前动画：{{ currentTransition }}
+      </div>
+    </Transition>
+
+    <!-- 切换显示/隐藏来触发动画 -->
+    <button @click="show = !show" class="toggle-btn">触发动画</button>
+
+    <!-- 用动态name触发进出动画 -->
+    <Transition :name="currentTransition">
+      <div v-if="show" class="content">我有动画效果哦</div>
+    </Transition>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+// 当前选中的过渡名称
+const currentTransition = ref("fade");
+
+// 控制元素的显示隐藏
+const show = ref(true);
+
+// 可选的过渡效果列表
+const transitions = [
+  { name: "fade", label: "淡入淡出" },
+  { name: "slide", label: "滑动" },
+  { name: "bounce", label: "弹跳" },
+];
+</script>
+
+<style>
+/* 淡入淡出效果 */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.5s ease;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+/* 滑动效果 */
+.slide-enter-active,
+.slide-leave-active {
+  transition: all 0.5s ease;
+}
+.slide-enter-from {
+  transform: translateX(-30px);
+  opacity: 0;
+}
+.slide-leave-to {
+  transform: translateX(30px);
+  opacity: 0;
+}
+
+/* 弹跳效果 */
+.bounce-enter-active {
+  animation: bounce-in 0.5s;
+}
+.bounce-leave-active {
+  animation: bounce-in 0.5s reverse;
+}
+
+@keyframes bounce-in {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+  50% {
+    transform: scale(1.1);
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+/* 样式 */
+.controls {
+  margin-bottom: 20px;
+}
+.controls button {
+  margin-right: 10px;
+  padding: 8px 16px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: white;
+  cursor: pointer;
+}
+.controls button.active {
+  background: #42b883;
+  color: white;
+  border-color: #42b883;
+}
+.box {
+  width: 200px;
+  height: 80px;
+  background: #42b883;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  margin: 20px 0;
+}
+.content {
+  padding: 20px;
+  background: #f0f0f0;
+  border-radius: 8px;
+  margin-top: 10px;
+}
+.toggle-btn {
+  margin-top: 10px;
+  padding: 8px 20px;
+  background: #35495e;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+</style>
+```
+
+这段代码的核心就是`:name="currentTransition"`——当`currentTransition`从`fade`变成`slide`，Transition组件就会去找`.slide-enter-active`这些CSS类名，动画效果自然就切换了。
+
+### 动态props：计算属性生成过渡参数
+
+除了动态name，你还可以通过计算属性动态生成Transition的其他属性。比如根据当前主题色来决定动画时长：
+
+```vue
+<!-- 动态props示例 -->
+<template>
+  <!-- 根据isDark动态切换不同的过渡配置 -->
+  <Transition
+    :name="transitionName"
+    :duration="isDark ? { enter: 800, leave: 600 } : { enter: 300, leave: 200 }"
+    mode="out-in"
+  >
+    <div :key="currentView" class="view">
+      {{ currentView }}
+    </div>
+  </Transition>
+</template>
+
+<script setup>
+import { ref, computed } from "vue";
+
+const isDark = ref(false);
+const currentView = ref("首页");
+
+// 根据主题动态选择过渡名称
+const transitionName = computed(() => {
+  return isDark.value ? "dark-fade" : "light-fade";
+});
+</script>
+```
+
+这种写法让过渡效果可以根据应用状态动态调整，灵活性拉满。暗色主题下动画慢一点、优雅一点；亮色主题下动画快一点、利落一点——用户体验一下子就不一样了。
+
+### 封装动态过渡组件
+
+把动态过渡也封装成组件，用起来更方便：
+
+```vue
+<!-- DynamicTransition.vue - 封装动态过渡组件 -->
+<template>
+  <Transition :name="currentName" v-bind="$attrs">
+    <slot></slot>
+  </Transition>
+</template>
+
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+  // 过渡类型：fade / slide / bounce
+  type: {
+    type: String,
+    default: "fade",
+  },
+  // 方向：up / down / left / right（用于slide类型）
+  direction: {
+    type: String,
+    default: "up",
+  },
+});
+
+// 根据type和direction计算最终的过渡名称
+const currentName = computed(() => {
+  if (props.type === "slide") {
+    return `slide-${props.direction}`;
+  }
+  return props.type;
+});
+</script>
+```
+
+使用的时候：
+
+```vue
+<!-- 滑动方向也能动态切换 -->
+<DynamicTransition :type="animType" :direction="animDirection">
+  <div v-if="show">内容</div>
+</DynamicTransition>
+```
+
+这样你就有了一个既能切换动画类型、又能控制方向的过渡组件，基本上覆盖了大部分场景。
+
+## 五、TransitionGroup——列表也能有动画
+
+### TransitionGroup是啥？
+
+到目前为止咱们聊的都是单个元素的过渡。但实际开发中，你经常会碰到列表的增删改——比如待办事项列表里加一条、删一条，或者标签列表里拖拽排序。这些操作如果硬邦邦地出现和消失，看着也不舒服。
+
+Vue 3提供了一个`<TransitionGroup>`组件，专门给列表加过渡动画。它和`<Transition>`有几个关键区别：
+
+| 特性         | Transition    | TransitionGroup         |
+| ------------ | ------------- | ----------------------- |
+| 包裹内容     | 单个元素/组件 | v-for列表               |
+| 渲染包裹元素 | 不渲染额外DOM | 默认不渲染（可配置tag） |
+| 移动动画     | 不支持        | 支持（通过FLIP动画）    |
+| key要求      | 不需要        | 每个列表项必须有唯一key |
+
+其中最厉害的是"移动动画"——当列表项的位置发生变化时（比如排序、删除中间项导致后面的项往前移），TransitionGroup可以自动给这些位移加上平滑的过渡效果。这个用的是FLIP动画技术（First, Last, Invert, Play），不用你自己算位置，Vue全帮你搞定了。
+
+### 基本用法
+
+```vue
+<!-- TransitionGroup基本示例 -->
+<template>
+  <div>
+    <button @click="addItem">添加项目</button>
+    <button @click="removeItem">删除项目</button>
+
+    <!-- TransitionGroup包裹v-for列表 -->
+    <!-- tag属性指定渲染的容器元素，不写就不渲染额外标签 -->
+    <TransitionGroup name="list" tag="ul">
+      <li v-for="item in items" :key="item.id" class="list-item">
+        {{ item.text }}
+        <button @click="removeById(item.id)">删除</button>
+      </li>
+    </TransitionGroup>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+// 初始列表数据
+const items = ref([
+  { id: 1, text: "学习Vue 3" },
+  { id: 2, text: "写博客文章" },
+  { id: 3, text: "喝杯咖啡" },
+]);
+
+// 自增ID
+let nextId = 4;
+
+// 添加项目
+function addItem() {
+  items.value.push({
+    id: nextId++,
+    text: `新项目 ${nextId - 1}`,
+  });
+}
+
+// 删除最后一个项目
+function removeItem() {
+  items.value.pop();
+}
+
+// 根据ID删除指定项目
+function removeById(id) {
+  const index = items.value.findIndex((item) => item.id === id);
+  if (index > -1) {
+    items.value.splice(index, 1);
+  }
+}
+</script>
+
+<style>
+/* 列表项进入动画 */
+.list-enter-active {
+  transition: all 0.5s ease;
+}
+
+/* 列表项离开动画 */
+.list-leave-active {
+  transition: all 0.3s ease;
+}
+
+/* 进入起始状态：从右侧滑入 + 透明 */
+.list-enter-from {
+  opacity: 0;
+  transform: translateX(30px);
+}
+
+/* 离开结束状态：向左滑出 + 透明 */
+.list-leave-to {
+  opacity: 0;
+  transform: translateX(-30px);
+}
+
+/* 关键！列表项移动时的过渡效果 */
+/* 没有这个，删除中间项时后面的项会"瞬移"而不是"滑动" */
+.list-move {
+  transition: transform 0.5s ease;
+}
+
+/* 离开的项脱离文档流，这样移动动画才不会被挡住 */
+.list-leave-active {
+  position: absolute;
+}
+
+.list-item {
+  padding: 10px 16px;
+  margin: 4px 0;
+  background: #f5f5f5;
+  border-radius: 4px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 300px;
+}
+</style>
+```
+
+有几个要点需要特别注意：
+
+1. **每个列表项必须有唯一的`key`**：不能用index，因为index会变，Vue就分不清哪个是哪个了
+2. **`.list-move`类**：这个是TransitionGroup专属的，控制列表项移动时的过渡效果。没有它，删除中间项时后面的项会瞬间跳过去
+3. **离开时`position: absolute`**：让正在离开的元素脱离文档流，这样其他元素的移动动画才不会被"卡住"
+
+TransitionGroup的功能远不止这些，比如还有自定义移动过渡、交错动画、和GSAP等动画库配合等高级用法。不过这些属于进阶内容了，咱们先把基础打牢，后面再单独开一篇细聊。
+
+## 课后 Quiz
+
+### 问题一：封装可复用Transition组件时，用`<slot>`的作用是啥？能不能不用slot？
+
+**答案解析：**
+
+`<slot>`的作用是接收父组件传进来的子内容，让MyTransition组件变成一个"壳子"——动画效果是固定的，但里面放什么内容由使用者决定。
+
+如果不用slot，你就得把内容硬编码在组件里，那这个组件就只能给那一个元素做动画了，完全失去了复用的意义。slot就像一个"占位符"，告诉Vue"这里将来会塞进来真正的DOM内容"。
+
+这就好比一个相框——框是固定的（过渡效果），但里面放什么照片（子内容）由你决定。没有slot就相当于相框和照片焊死在一起了，那还叫啥相框。
+
+### 问题二：动态过渡中，`:name="transitionName"`切换动画类型的原理是啥？
+
+**答案解析：**
+
+Transition组件的`name`属性决定了CSS类名的前缀。比如`name="fade"`时，Vue会找`.fade-enter-active`、`.fade-leave-active`这些类名；`name="slide"`时，就找`.slide-enter-active`、`.slide-leave-active`。
+
+当`transitionName`的值从`fade`变成`slide`时，Transition组件下次触发过渡时就会使用新的类名前缀，对应的CSS样式不同，动画效果自然就不同了。
+
+需要注意的是，name的切换不会影响当前正在执行的动画——它只影响下一次触发的过渡。所以切换name之后，需要再次触发元素的显示/隐藏（比如v-if从false变true）才能看到新动画效果。
+
+### 问题三：TransitionGroup中`.list-move`类和离开时`position: absolute`分别起什么作用？
+
+**答案解析：**
+
+`.list-move`类控制的是列表项位置变化时的过渡效果。当你删除列表中间的一项时，后面的项需要往前移填补空位。没有`.list-move`，这个移动是瞬间完成的；有了它，移动就有了平滑的过渡动画。
+
+离开时设置`position: absolute`是因为：正在执行离开动画的元素还占据着文档流中的位置，这会导致后面的元素无法开始移动动画（因为位置还没空出来）。把离开的元素设为绝对定位，它就脱离了文档流，其他元素就可以立刻开始移动了。
+
+这两个配合起来，才能实现"删一项，后面的项平滑滑过来"的效果。缺了任何一个，动画都会"卡"或者"跳"。
+
+## 常见报错解决方案
+
+### 报错一：`<Transition> expects exactly one child element or component`
+
+**产生原因：**
+
+Transition组件只能包裹一个直接子元素。如果你在里面放了多个兄弟元素，或者啥都没放，Vue就会报这个错。
+
+**解决方案：**
+
+确保Transition里面只有一个直接子元素。如果有多个元素需要同时动画，用`<template>`不行（template不是真实DOM），应该用`<TransitionGroup>`或者把多个元素包在一个`<div>`里。
+
+```vue
+<!-- 错误写法：两个兄弟元素 -->
+<Transition>
+  <div v-if="show">内容1</div>
+  <div v-if="show">内容2</div>
+</Transition>
+
+<!-- 正确写法一：包在一个div里 -->
+<Transition>
+  <div v-if="show">
+    <div>内容1</div>
+    <div>内容2</div>
+  </div>
+</Transition>
+
+<!-- 正确写法二：用TransitionGroup -->
+<TransitionGroup name="fade">
+  <div v-if="show" key="1">内容1</div>
+  <div v-if="show" key="2">内容2</div>
+</TransitionGroup>
+```
+
+**预防建议：** 每次写Transition的时候，养成习惯检查里面是不是只有一个直接子元素。
+
+### 报错二：封装的Transition组件动画不生效
+
+**产生原因：**
+
+最常见的原因是CSS类名前缀和`name`属性不匹配。比如你设了`name="my-transition"`，但CSS写的是`.fade-enter-active`，那Vue根本找不到对应的样式。
+
+另一个常见原因是`<style scoped>`导致的。scoped会给CSS选择器加上属性选择器，但Transition组件动态添加的CSS类名可能无法正确匹配。
+
+**解决方案：**
+
+1. 确保CSS类名前缀和name属性一致
+2. 如果用了scoped，过渡相关的CSS要么不加scoped，要么用`:deep()`穿透
+
+```vue
+<!-- 确保name和CSS前缀一致 -->
+<Transition name="my-fade">
+  <div v-if="show">内容</div>
+</Transition>
+
+<!-- 对应的CSS必须是 .my-fade-xxx -->
+<style>
+/* 不要加scoped，或者用:deep() */
+.my-fade-enter-active {
+  transition: opacity 0.5s ease;
+}
+.my-fade-enter-from {
+  opacity: 0;
+}
+</style>
+```
+
+**预防建议：** 封装组件时，先在非scoped环境下测试动画是否生效，确认没问题后再处理样式隔离问题。
+
+### 报错三：TransitionGroup列表项移动时没有动画，直接"瞬移"
+
+**产生原因：**
+
+缺少`.xxx-move`类的过渡样式，或者离开的元素没有设置`position: absolute`。这两个缺一不可——move类提供移动过渡效果，absolute让离开的元素让出位置。
+
+**解决方案：**
+
+确保同时添加move过渡类和离开时的绝对定位：
+
+```css
+/* 必须有这个！控制移动动画 */
+.list-move {
+  transition: transform 0.5s ease;
+}
+
+/* 离开时脱离文档流，让其他元素能移动 */
+.list-leave-active {
+  transition: all 0.3s ease;
+  position: absolute; /* 关键！ */
+}
+
+.list-leave-to {
+  opacity: 0;
+}
+```
+
+**预防建议：** 每次用TransitionGroup的时候，把move类和absolute定位当作"标配"一起写上，别等出了问题再补。
+
+参考链接：https://vuejs.org/guide/built-ins/transition.html
+
+余下文章内容请点击跳转至 个人博客页面 或者 扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`，阅读完整的文章：[把Transition包成组件复用，还能动态切换动画效果](https://blog.cmdragon.cn/posts/f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7/)
+
+<details>
+<summary>往期文章归档</summary>
+
+- [Vue 3 静态与动态 Props 如何传递？TypeScript 类型约束有何必要？](https://blog.cmdragon.cn/posts/94ab48753b64780ca3ab7a7115ae8522/)
+- [Vue 3中组件局部注册的优势与实现方式如何？](https://blog.cmdragon.cn/posts/dbf576e744870f6de26fd8a2e03e47da/)
+- [如何在Vue3中优化生命周期钩子性能并规避常见陷阱？](https://blog.cmdragon.cn/posts/12d98b3b9ccd6c19a1b169d720ac5c80/)
+- [Vue 3 Composition API生命周期钩子：如何实现从基础理解到高阶复用？](https://blog.cmdragon.cn/posts/8884e2b70287fcb263c57648eeb27419/)
+- [Vue 3生命周期钩子实战指南：如何正确选择onMounted、onUpdated与onUnmounted的应用场景？](https://blog.cmdragon.cn/posts/883c6dbc50ae4183770a4462e0b8ae4d/)
+- [Vue 3中生命周期钩子与响应式系统如何实现协同工作？](https://blog.cmdragon.cn/posts/70dad360ffa9dce14d0d69611b8cb019/)
+- [Vue 3组件生命周期钩子的执行顺序与使用场景是什么？](https://blog.cmdragon.cn/posts/db44294a78dc9f666f67b053f6c83567/)
+- [Vue组件全局注册与局部注册如何抉择？](https://blog.cmdragon.cn/posts/43ead630ea17da65d99ad2eb8188e472/)
+- [Vue3组件化开发中，Props与Emits如何实现数据流转与事件协作？](https://blog.cmdragon.cn/posts/8cff7d2df113da66ea7be560c4d1d22a/)
+- [Vue 3模板引用如何与其他特性协同实现复杂交互？](https://blog.cmdragon.cn/posts/331bf75d114ab09116eadfcdca602b58/)
+- [Vue 3 v-for中模板引用如何实现高效管理与动态控制？](https://blog.cmdragon.cn/posts/cb380897ddc3578b180ecf8843c774c1/)
+- [Vue 3的defineExpose：如何突破script setup组件默认封装，实现精准的父子通讯？](https://blog.cmdragon.cn/posts/202ae0f4acde7128e0e31baf63732fb5/)
+- [Vue 3模板引用的生命周期时机如何把握？常见陷阱该如何避免？](https://blog.cmdragon.cn/posts/7d2a0f6555ecbe92afd7d2491c427463/)
+- [Vue 3模板引用如何实现父组件与子组件的高效交互？](https://blog.cmdragon.cn/posts/3fb7bdd84128b7efaaa1c979e1f28dee/)
+- [Vue中为何需要模板引用？又如何高效实现DOM与组件实例的直接访问？](https://blog.cmdragon.cn/posts/23f3464ba16c7054b4783cded50c04c6/)
+
+</details>
+
+<details>
+<summary>免费好用的热门在线工具</summary>
+
+- [多直播聚合器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/multi-live-aggregator)
+- [Proto文件生成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/proto-file-generator)
+- [图片转粒子 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/image-to-particles)
+- [视频下载器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/video-downloader)
+- [文件格式转换器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/file-converter)
+- [M3U8在线播放器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/m3u8-player)
+- [快图设计 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/quick-image-design)
+- [高级文字转图片转换器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/text-to-image-advanced)
+- [RAID 计算器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/raid-calculator)
+- [在线PS - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/photoshop-online)
+- [Mermaid 在线编辑器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/mermaid-live-editor)
+- [数学求解计算器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/math-solver-calculator)
+- [智能提词器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/smart-teleprompter)
+- [魔法简历 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/magic-resume)
+- [Image Puzzle Tool - 图片拼图工具 | By cmdragon](https://tools.cmdragon.cn/zh/apps/image-puzzle-tool)
+- [字幕下载工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/subtitle-downloader)
+- [歌词生成工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/lyrics-generator)
+- [网盘资源聚合搜索 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/cloud-drive-search)
+- [ASCII字符画生成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/ascii-art-generator)
+- [JSON Web Tokens 工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/jwt-tool)
+- [Bcrypt 密码工具 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/bcrypt-tool)
+- [GIF 合成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/gif-composer)
+- [GIF 分解器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/gif-decomposer)
+- [文本隐写术 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/text-steganography)
+- [CMDragon 在线工具 - 高级AI工具箱与开发者套件 | 免费好用的在线工具](https://tools.cmdragon.cn/zh)
+- [应用商店 - 发现1000+提升效率与开发的AI工具和实用程序 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps?category=trending)
+- [CMDragon 更新日志 - 最新更新、功能与改进 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/changelog)
+- [支持我们 - 成为赞助者 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/sponsor)
+- [AI文本生成图像 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/text-to-image-ai)
+- [临时邮箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/temp-email)
+- [二维码解析器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/qrcode-parser)
+- [文本转思维导图 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/text-to-mindmap)
+- [正则表达式可视化工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/regex-visualizer)
+- [文件隐写工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/steganography-tool)
+- [IPTV 频道探索器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/iptv-explorer)
+- [快传 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/snapdrop)
+- [随机抽奖工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/lucky-draw)
+- [动漫场景查找器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/anime-scene-finder)
+- [时间工具箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/time-toolkit)
+- [网速测试 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/speed-test)
+- [AI 智能抠图工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/background-remover)
+- [背景替换工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/background-replacer)
+- [艺术二维码生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/artistic-qrcode)
+- [Open Graph 元标签生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/open-graph-generator)
+- [图像对比工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/image-comparison)
+- [图片压缩专业版 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/image-compressor)
+- [密码生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/password-generator)
+- [SVG优化器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/svg-optimizer)
+- [调色板生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/color-palette)
+- [在线节拍器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/online-metronome)
+- [IP归属地查询 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/ip-geolocation)
+- [CSS网格布局生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/css-grid-layout)
+- [邮箱验证工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/email-validator)
+- [书法练习字帖 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/calligraphy-practice)
+- [金融计算器套件 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/finance-calculator-suite)
+- [中国亲戚关系计算器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/chinese-kinship-calculator)
+- [Protocol Buffer 工具箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/protobuf-toolkit)
+- [IP归属地查询 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/ip-geolocation)
+- [图片无损放大 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/image-upscaler)
+- [文本比较工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/text-compare)
+- [IP批量查询工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/ip-batch-lookup)
+- [域名查询工具 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/domain-finder)
+- [DNS工具箱 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/dns-toolkit)
+- [网站图标生成器 - 应用商店 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps/favicon-generator)
+- [XML Sitemap](https://tools.cmdragon.cn/sitemap_index.xml)
+
+</details>


### PR DESCRIPTION
新增了三篇关于Vue 3 Transition组件的技术博客：
1. 基础入门篇：讲解Transition组件核心概念、6个CSS类名、触发时机
2. 进阶细节篇：覆盖嵌套元素过渡、duration属性、appear属性、key触发过渡等易忽略细节
3. 过渡模式篇：详解out-in/in-out两种过渡模式，解决多元素切换撞车问题

文章均包含完整代码示例、流程图解析、常见报错解决方案，适合Vue开发者系统学习Transition组件使用。