### PR TITLE
docs: 添加6篇Vue3 KeepAlias系列博客文章

### DIFF
--- a/content/posts/front_end/vue/KeepAlive搭配Vue Router，页面缓存到底怎么玩.md
+++ b/content/posts/front_end/vue/KeepAlive搭配Vue Router，页面缓存到底怎么玩.md
@@ -1,0 +1,447 @@
+---
+url: /posts/k5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0/
+title: KeepAlive搭配Vue Router，页面缓存到底怎么玩
+date: 2026-05-19T16:00:00+08:00
+lastmod: 2026-05-19T16:00:00+08:00
+author: cmdragon
+cover: https://api2.cmdragon.cn/upload/cmder/images/2026年6月7日 22_42_36.png
+
+summary: 动态组件缓存搞定了，但实际项目中更常见的是路由页面缓存。KeepAlive配合Vue Router的router-view，再加上路由meta信息动态控制哪些页面该缓存，这才是KeepAlive最实用的打开方式。
+
+categories:
+  - vue
+
+tags:
+  - 基础入门
+  - KeepAlive
+  - Vue Router
+  - 路由缓存
+  - router-view
+  - meta信息
+---
+
+<img src="https://api2.cmdragon.cn/upload/cmder/images/2026年6月7日 22_42_36.png" title="cover.png" alt="cmdragon_cn.png"/>
+
+<img src="https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg" title="cmdragon_cn.png" alt="cmdragon_cn.png"/>
+
+扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`
+
+[发现1000+提升效率与开发的AI工具和实用程序](https://tools.cmdragon.cn/zh/apps?category=ai_chat)：https://tools.cmdragon.cn/
+
+## 一、从动态组件到路由页面
+
+前面几篇咱学的KeepAlive都是配合 `<component :is="xxx">` 动态组件来用的，但说实话，实际项目里很少有人用动态组件来做页面切换。大家更常用的是Vue Router——通过路由来切换页面。
+
+那问题来了：**KeepAlive能配合Vue Router用吗？**
+
+当然能！`<router-view>` 本质上也是一个动态组件，它根据当前路由动态渲染对应的页面组件。所以KeepAlive包router-view是完全没问题的。
+
+```mermaid
+flowchart LR
+    A[Vue Router] -->|匹配路由| B[router-view]
+    B -->|动态渲染| C[页面组件]
+    D[KeepAlive] -->|包裹router-view| B
+    D -->|缓存页面组件| C
+```
+
+## 二、最简单的路由缓存
+
+最简单的用法，直接用KeepAlive包router-view：
+
+```vue
+<!-- App.vue -->
+<template>
+  <nav>
+    <router-link to="/list">列表页</router-link>
+    <router-link to="/detail">详情页</router-link>
+  </nav>
+
+  <router-view v-slot="{ Component }">
+    <KeepAlive>
+      <component :is="Component" />
+    </KeepAlive>
+  </router-view>
+</template>
+```
+
+注意这里用了 `v-slot="{ Component }"` 来获取router-view渲染的组件，然后用 `<component :is="Component" />` 来渲染它。这是Vue Router官方推荐的写法，因为KeepAlive需要直接包裹一个组件元素。
+
+这样写之后，**所有路由页面都会被缓存**。但问题跟之前一样——不是所有页面都需要缓存。
+
+## 三、用路由meta控制缓存
+
+更好的做法是在路由配置中用 `meta` 字段标记哪些页面需要缓存，然后动态生成include列表。
+
+### 第一步：路由配置中标记
+
+```javascript
+// router/index.js
+import { createRouter, createWebHistory } from "vue-router";
+
+const routes = [
+  {
+    path: "/list",
+    name: "ListPage",
+    component: () => import("../views/ListPage.vue"),
+    meta: { keepAlive: true }, // 需要缓存
+  },
+  {
+    path: "/detail/:id",
+    name: "DetailPage",
+    component: () => import("../views/DetailPage.vue"),
+    meta: { keepAlive: false }, // 不需要缓存
+  },
+  {
+    path: "/settings",
+    name: "SettingsPage",
+    component: () => import("../views/SettingsPage.vue"),
+    meta: { keepAlive: true }, // 需要缓存
+  },
+];
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes,
+});
+
+export default router;
+```
+
+### 第二步：动态生成include
+
+```vue
+<!-- App.vue -->
+<script setup>
+import { computed } from "vue";
+import { useRouter } from "vue-router";
+
+const router = useRouter();
+
+// 从路由配置中收集所有需要缓存的路由name
+const keepAliveInclude = computed(() => {
+  return router
+    .getRoutes()
+    .filter((route) => route.meta.keepAlive)
+    .map((route) => route.name);
+});
+</script>
+
+<template>
+  <nav>
+    <router-link to="/list">列表页</router-link>
+    <router-link to="/detail">详情页</router-link>
+    <router-link to="/settings">设置页</router-link>
+  </nav>
+
+  <router-view v-slot="{ Component }">
+    <KeepAlive :include="keepAliveInclude">
+      <component :is="Component" />
+    </KeepAlive>
+  </router-view>
+</template>
+```
+
+这样只有 `meta.keepAlive` 为 `true` 的页面才会被缓存，其他页面切换时正常销毁和重建。
+
+### 第三步：确保组件name和路由name一致
+
+这是最容易踩坑的地方——**include匹配的是组件的name，不是路由的name**。但我们在include里用的是路由的name，所以必须确保两者一致。
+
+```vue
+<!-- ListPage.vue -->
+<script setup>
+// 文件名是ListPage.vue，自动生成的name就是ListPage
+// 和路由配置里的name: 'ListPage'一致，没问题
+</script>
+```
+
+如果文件名和路由name不一致，需要手动声明：
+
+```vue
+<script setup>
+defineOptions({ name: "ListPage" }); // 手动声明，确保和路由name一致
+</script>
+```
+
+## 四、列表页到详情页再返回的经典场景
+
+这是KeepAlive配合Vue Router最常见的场景：用户在列表页浏览，点击进入详情页，然后返回列表页，希望列表页的状态（滚动位置、筛选条件、已加载数据）还在。
+
+### 路由配置
+
+```javascript
+const routes = [
+  {
+    path: "/list",
+    name: "ListPage",
+    component: () => import("../views/ListPage.vue"),
+    meta: { keepAlive: true }, // 列表页需要缓存
+  },
+  {
+    path: "/detail/:id",
+    name: "DetailPage",
+    component: () => import("../views/DetailPage.vue"),
+    meta: { keepAlive: false }, // 详情页不需要缓存
+  },
+];
+```
+
+### 列表页组件
+
+```vue
+<!-- ListPage.vue -->
+<script setup>
+import { ref, onActivated, onDeactivated } from "vue";
+import { useRouter } from "vue-router";
+
+defineOptions({ name: "ListPage" });
+
+const router = useRouter();
+const list = ref([]);
+const scrollTop = ref(0);
+const searchQuery = ref("");
+const lastFetchTime = ref(null);
+const listRef = ref(null);
+
+async function fetchData(force = false) {
+  if (!force && lastFetchTime.value) {
+    const elapsed = Date.now() - lastFetchTime.value;
+    if (elapsed < 60000) return; // 1分钟内不刷新
+  }
+
+  const res = await fetch(`/api/list?q=${searchQuery.value}`);
+  list.value = await res.json();
+  lastFetchTime.value = Date.now();
+}
+
+function goToDetail(id) {
+  router.push(`/detail/${id}`);
+}
+
+onActivated(() => {
+  if (listRef.value && scrollTop.value) {
+    listRef.value.scrollTop = scrollTop.value;
+  }
+  fetchData();
+});
+
+onDeactivated(() => {
+  if (listRef.value) {
+    scrollTop.value = listRef.value.scrollTop;
+  }
+});
+
+// 初始加载
+fetchData(true);
+</script>
+
+<template>
+  <div>
+    <input
+      v-model="searchQuery"
+      placeholder="搜索..."
+      @keyup.enter="fetchData(true)"
+    />
+    <div ref="listRef" style="height: 600px; overflow-y: auto;">
+      <div v-for="item in list" :key="item.id" @click="goToDetail(item.id)">
+        {{ item.name }}
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+### 详情页组件
+
+```vue
+<!-- DetailPage.vue -->
+<script setup>
+import { ref, onMounted } from "vue";
+import { useRoute } from "vue-router";
+
+defineOptions({ name: "DetailPage" });
+
+const route = useRoute();
+const detail = ref(null);
+
+onMounted(async () => {
+  const res = await fetch(`/api/detail/${route.params.id}`);
+  detail.value = await res.json();
+});
+</script>
+
+<template>
+  <div v-if="detail">
+    <h2>{{ detail.title }}</h2>
+    <p>{{ detail.content }}</p>
+  </div>
+</template>
+```
+
+## 五、动态添加和移除缓存
+
+有些场景更复杂——同一个页面，有时候需要缓存，有时候不需要。
+
+比如：从列表页进入详情页时缓存列表页，但从详情页进入编辑页时不缓存详情页。或者用户手动刷新了列表页，需要清除缓存重新加载。
+
+### 方案1：响应式include数组
+
+```vue
+<script setup>
+import { ref, computed } from "vue";
+import { useRouter } from "vue-router";
+
+const router = useRouter();
+const cachedViews = ref(new Set());
+
+// 初始化：从路由meta中收集需要缓存的页面
+router.getRoutes().forEach((route) => {
+  if (route.meta.keepAlive) {
+    cachedViews.value.add(route.name);
+  }
+});
+
+const keepAliveInclude = computed(() => Array.from(cachedViews.value));
+
+// 动态添加缓存
+function addCache(viewName) {
+  cachedViews.value.add(viewName);
+}
+
+// 动态移除缓存
+function removeCache(viewName) {
+  cachedViews.value.delete(viewName);
+}
+</script>
+```
+
+### 方案2：路由守卫中控制
+
+在组件内用 `onBeforeRouteLeave` 判断离开方向：
+
+```vue
+<script setup>
+import { onBeforeRouteLeave } from "vue-router";
+
+onBeforeRouteLeave((to, from) => {
+  // 如果是去详情页，缓存当前列表页
+  if (to.name === "DetailPage") {
+    // 列表页已经在include里了，不用额外操作
+  }
+  // 如果是去其他页面，可以考虑移除缓存
+});
+</script>
+```
+
+## 六、多级路由的缓存问题
+
+如果你的路由是嵌套的（多级路由），要注意每一层的 `router-view` 都需要单独处理KeepAlive。
+
+```javascript
+const routes = [
+  {
+    path: "/",
+    component: Layout,
+    children: [
+      {
+        path: "list",
+        name: "ListPage",
+        component: () => import("../views/ListPage.vue"),
+        meta: { keepAlive: true },
+      },
+    ],
+  },
+];
+```
+
+在Layout组件中：
+
+```vue
+<!-- Layout.vue -->
+<template>
+  <div>
+    <sidebar />
+    <main>
+      <router-view v-slot="{ Component }">
+        <KeepAlive :include="keepAliveInclude">
+          <component :is="Component" />
+        </KeepAlive>
+      </router-view>
+    </main>
+  </div>
+</template>
+```
+
+注意事项：
+
+1. KeepAlive要放在最内层的router-view旁边
+2. 嵌套路由中，父组件Layout不会被KeepAlive缓存（它一直都在），只有子页面组件会被缓存
+3. 确保组件name在所有层级都是唯一的
+
+## 课后Quiz
+
+### 问题1：KeepAlive配合router-view时，include匹配的是路由的path还是组件的name？
+
+**答案解析：** 匹配的是**组件的name**，不是路由的path。include/exclude始终根据组件的name选项来匹配。所以路由配置中的name要和组件的name保持一致，否则缓存不生效。
+
+### 问题2：如何在路由配置中标记哪些页面需要缓存？
+
+**答案解析：** 在路由配置的meta字段中添加自定义标记，比如 `meta: { keepAlive: true }`。然后在App.vue中通过 `router.getRoutes()` 收集所有 `meta.keepAlive` 为true的路由name，动态生成include列表。
+
+## 常见报错解决方案
+
+### 1. 路由缓存不生效
+
+**错误现象：** 配了meta.keepAlive和include，但页面切换后状态还是丢了。
+
+**可能原因：** 组件的name和路由的name不一致。include匹配的是组件name，如果组件自动生成的name（来自文件名）和路由配置的name对不上，就不会被缓存。
+
+**解决方案：** 在组件中用 `defineOptions({ name: 'xxx' })` 手动声明name，确保和路由name一致。
+
+### 2. 所有页面都被缓存了
+
+**错误现象：** 没有设置include，所有路由页面都被缓存了。
+
+**可能原因：** KeepAlive默认缓存所有子组件，没有设置include过滤。
+
+**解决方案：** 添加 `:include` 属性，只缓存需要的页面。
+
+### 3. 返回列表页数据没有刷新
+
+**错误现象：** 从详情页返回列表页，看到的是旧数据。
+
+**可能原因：** 缓存的列表页数据没有更新。KeepAlive只负责保持状态，不会自动刷新数据。
+
+**解决方案：** 在列表页的 `onActivated` 钩子中判断是否需要刷新数据。可以用时间戳判断数据是否过期，或者用路由query参数标记是否需要刷新。
+
+参考链接：
+
+- https://cn.vuejs.org/guide/built-ins/keep-alive.html
+- https://router.vuejs.org/zh/guide/advanced/navigation-guards.html
+
+余下文章内容请点击跳转至 个人博客页面 或者 扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`，阅读完整的文章：[KeepAlive搭配Vue Router，页面缓存到底怎么玩](https://blog.cmdragon.cn/posts/k5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0/)
+
+<details>
+<summary>往期文章归档</summary>
+
+- [Vue 3 静态与动态 Props 如何传递？TypeScript 类型约束有何必要？](https://blog.cmdragon.cn/posts/94ab48753b64780ca3ab7a7115ae8522/)
+- [Vue 3中组件局部注册的优势与实现方式如何？](https://blog.cmdragon.cn/posts/dbf576e744870f6de26fd8a2e03e47da/)
+- [如何在Vue3中优化生命周期钩子性能并规避常见陷阱？](https://blog.cmdragon.cn/posts/12d98b3b9ccd6c19a1b169d720ac5c80/)
+- [Vue 3 Composition API生命周期钩子：如何实现从基础理解到高阶复用？](https://blog.cmdragon.cn/posts/8884e2b70287fcb263c57648eeb27419/)
+- [Vue 3生命周期钩子实战指南：如何正确选择onMounted、onUpdated与onUnmounted的应用场景？](https://blog.cmdragon.cn/posts/883c6dbc50ae4183770a4462e0b8ae4d/)
+
+</details>
+
+<details>
+<summary>免费好用的热门在线工具</summary>
+
+- [多直播聚合器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/multi-live-aggregator)
+- [Proto文件生成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/proto-file-generator)
+- [图片转粒子 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/image-to-particles)
+- [视频下载器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/video-downloader)
+- [文件格式转换器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/file-converter)
+- [M3U8在线播放器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/m3u8-player)
+- [CMDragon 在线工具 - 高级AI工具箱与开发者套件 | 免费好用的在线工具](https://tools.cmdragon.cn/zh)
+- [应用商店 - 发现1000+提升效率与开发的AI工具和实用程序 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps?category=trending)
+
+</details>

--- a/content/posts/front_end/vue/KeepAlive踩坑指南——内存泄漏、数据陈旧和不该用的场景.md
+++ b/content/posts/front_end/vue/KeepAlive踩坑指南——内存泄漏、数据陈旧和不该用的场景.md
@@ -1,0 +1,402 @@
+---
+url: /posts/k6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1/
+title: KeepAlive踩坑指南——内存泄漏、数据陈旧和不该用的场景
+date: 2026-05-19T16:30:00+08:00
+lastmod: 2026-05-19T16:30:00+08:00
+author: cmdragon
+cover: https://api2.cmdragon.cn/upload/cmder/images/2026年6月7日 22_47_14.png
+
+summary: KeepAlive好用但坑也不少：缓存组件里的定时器没清理会内存泄漏，缓存的数据太久不更新会变成"僵尸数据"，有些场景根本就不该用KeepAlive。这篇踩坑指南帮你避开所有雷区，附完整最佳实践总结。
+
+categories:
+  - vue
+
+tags:
+  - 基础入门
+  - KeepAlive
+  - 内存泄漏
+  - 数据陈旧
+  - 最佳实践
+  - 性能优化
+---
+
+<img src="https://api2.cmdragon.cn/upload/cmder/images/2026年6月7日 22_47_14.png" title="cover.png" alt="cmdragon_cn.png"/>
+
+<img src="https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg" title="cmdragon_cn.png" alt="cmdragon_cn.png"/>
+
+扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`
+
+[发现1000+提升效率与开发的AI工具和实用程序](https://tools.cmdragon.cn/zh/apps?category=ai_chat)：https://tools.cmdragon.cn/
+
+## 一、坑1：内存泄漏——缓存组件里的"定时炸弹"
+
+KeepAlive缓存组件很爽，但很多人忽略了一个严重问题——**缓存组件里的定时器和事件监听器不会自动清理**。
+
+组件虽然去冬眠了，但setInterval还在后台跑着呢，跟偷电一样。你每缓存一个带定时器的组件，就多了一个"定时炸弹"，内存占用蹭蹭往上涨。
+
+### 错误写法
+
+```vue
+<script setup>
+import { onMounted } from "vue";
+
+let timer = null;
+
+onMounted(() => {
+  // 每5秒轮询一次数据
+  timer = setInterval(() => {
+    console.log("轮询中...");
+    fetchData();
+  }, 5000);
+});
+
+// 问题：组件被缓存时，timer不会停止！
+// 切走后这个定时器还在跑，白占资源
+</script>
+```
+
+### 正确写法
+
+```vue
+<script setup>
+import { onMounted, onActivated, onDeactivated, onUnmounted } from "vue";
+
+let timer = null;
+
+function startPolling() {
+  stopPolling(); // 先停掉之前的，防止重复
+  timer = setInterval(() => {
+    console.log("轮询中...");
+    fetchData();
+  }, 5000);
+}
+
+function stopPolling() {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}
+
+onMounted(() => {
+  startPolling();
+});
+
+// 冬眠时暂停定时器
+onDeactivated(() => {
+  stopPolling();
+});
+
+// 唤醒时恢复定时器
+onActivated(() => {
+  startPolling();
+});
+
+// 真正销毁时也清理
+onUnmounted(() => {
+  stopPolling();
+});
+</script>
+```
+
+同样的道理，addEventListener也要在onDeactivated中removeEventListener，否则事件监听器会越积越多。
+
+## 二、坑2：数据陈旧——缓存里的"僵尸数据"
+
+缓存组件的数据不会自动更新。用户切走5分钟再切回来，看到的还是5分钟前的旧数据。如果是用户信息、订单状态、库存数量这种实时性要求高的数据，那可就出大问题了。
+
+### 解决方案1：onActivated中智能刷新
+
+```vue
+<script setup>
+import { ref, onActivated } from "vue";
+
+const dataList = ref([]);
+const lastFetchTime = ref(0);
+
+onActivated(() => {
+  const now = Date.now();
+  const elapsed = now - lastFetchTime.value;
+
+  // 超过2分钟就刷新
+  if (elapsed > 2 * 60 * 1000) {
+    fetchData();
+  }
+});
+
+async function fetchData() {
+  const res = await fetch("/api/list");
+  dataList.value = await res.json();
+  lastFetchTime.value = Date.now();
+}
+</script>
+```
+
+### 解决方案2：结合Pinia做数据版本控制
+
+```vue
+<script setup>
+import { onActivated } from "vue";
+import { useDataStore } from "@/stores/data";
+
+const dataStore = useDataStore();
+
+onActivated(() => {
+  // 检查store中的数据版本是否更新了
+  if (dataStore.listVersion > currentVersion) {
+    dataList.value = dataStore.list;
+    currentVersion = dataStore.listVersion;
+  }
+});
+</script>
+```
+
+### 解决方案3：路由meta标记强制刷新
+
+```javascript
+// 从详情页返回时，在query中标记需要刷新
+router.push({ path: "/list", query: { refresh: "1" } });
+```
+
+```vue
+<script setup>
+import { onActivated } from "vue";
+import { useRoute } from "vue-router";
+
+const route = useRoute();
+
+onActivated(() => {
+  if (route.query.refresh === "1") {
+    fetchData();
+  }
+});
+</script>
+```
+
+## 三、坑3：不该用KeepAlive的场景
+
+不是所有东西都该放冰箱的，热菜放进去反而坏了。KeepAlive也一样，有些场景用了反而添乱。
+
+| 适合缓存的场景               | 不适合缓存的场景               |
+| ---------------------------- | ------------------------------ |
+| 列表页（保留滚动位置和筛选） | 实时监控页（数据需要持续更新） |
+| 表单填写页（防止误切丢失）   | 表单提交成功页（一次性展示）   |
+| 设置页（切换回来不重载）     | 支付页（敏感信息不该缓存）     |
+| 搜索页（保留搜索历史）       | 引导页/欢迎页（只展示一次）    |
+| 多步骤表单（保留进度）       | 数据变化频繁的仪表盘           |
+
+说白了，**只有用户需要"回来继续"的页面才值得缓存**。如果用户每次进入都期望看到最新数据，那就别缓存。
+
+## 四、坑4：KeepAlive和Transition一起用
+
+想让缓存组件切换时有点过渡动画？那KeepAlive和Transition就得一起上场了。但**嵌套顺序很重要**！
+
+### 正确顺序：Transition在外，KeepAlive在内
+
+```vue
+<router-view v-slot="{ Component }">
+  <Transition name="fade" mode="out-in">
+    <KeepAlive>
+      <component :is="Component" />
+    </KeepAlive>
+  </Transition>
+</router-view>
+```
+
+### 错误顺序：KeepAlive在外，Transition在内
+
+```vue
+<!-- 这样过渡动画可能不生效！ -->
+<router-view v-slot="{ Component }">
+  <KeepAlive>
+    <Transition name="fade" mode="out-in">
+      <component :is="Component" />
+    </Transition>
+  </KeepAlive>
+</router-view>
+```
+
+为啥呢？因为Transition需要监听子组件的挂载/卸载来触发动画。如果KeepAlive在外面，组件切走时不会被卸载（只是deactivated），Transition就感知不到变化，动画自然就不生效了。
+
+把Transition放在外面，KeepAlive在里面，这样Transition能看到组件的"出现"和"消失"，动画就能正常播放了。
+
+## 五、坑5：缓存组件的props更新问题
+
+缓存组件有个容易忽略的问题：**组件被缓存后，props变化时组件会更新但不会重新创建**。
+
+如果你的组件在onMounted中根据props初始化数据，那缓存后props变化时，onMounted不会再触发，初始化逻辑就不会重新执行。
+
+### 问题代码
+
+```vue
+<script setup>
+import { ref, onMounted } from "vue";
+
+const props = defineProps(["userId"]);
+const userData = ref(null);
+
+onMounted(async () => {
+  // 只有首次挂载时执行
+  // 缓存后userId变了，这里不会再执行！
+  const res = await fetch(`/api/user/${props.userId}`);
+  userData.value = await res.json();
+});
+</script>
+```
+
+### 解决方案1：watch监听props
+
+```vue
+<script setup>
+import { ref, watch } from "vue";
+
+const props = defineProps(["userId"]);
+const userData = ref(null);
+
+async function loadUser(id) {
+  const res = await fetch(`/api/user/${id}`);
+  userData.value = await res.json();
+}
+
+// props变化时重新加载
+watch(
+  () => props.userId,
+  (newId) => {
+    loadUser(newId);
+  },
+  { immediate: true },
+);
+</script>
+```
+
+### 解决方案2：onActivated中处理
+
+```vue
+<script setup>
+import { ref, onActivated } from "vue";
+
+const props = defineProps(["userId"]);
+const userData = ref(null);
+
+onActivated(async () => {
+  // 每次激活时根据当前props重新加载
+  const res = await fetch(`/api/user/${props.userId}`);
+  userData.value = await res.json();
+});
+</script>
+```
+
+### 解决方案3：用key强制重建
+
+如果你就是想让某些情况下组件重新创建，可以用key：
+
+```vue
+<KeepAlive>
+  <UserDetail :key="userId" :user-id="userId" />
+</KeepAlive>
+```
+
+当key变化时，KeepAlive会销毁旧实例创建新实例。但这样缓存就失效了，所以只在确实需要的时候才用。
+
+## 六、最佳实践总结
+
+```mermaid
+flowchart TD
+    A[需要缓存组件吗?] --> B{用户切回来时<br>需要保留之前的状态吗?}
+    B -->|不需要| C[不用KeepAlive]
+    B -->|需要| D{数据实时性要求高吗?}
+    D -->|很高| E[用KeepAlive<br>但onActivated中刷新数据]
+    D -->|不高| F[用KeepAlive<br>正常缓存即可]
+    E --> G{缓存组件多吗?}
+    F --> G
+    G -->|多| H[设置include/exclude<br>+ max限制]
+    G -->|少| I[只设include即可]
+    H --> J[onDeactivated清理资源<br>onActivated恢复/刷新]
+    I --> J
+```
+
+**核心原则：**
+
+1. **只缓存需要的组件** — 用include/exclude精准控制
+2. **设置合理的max限制** — 防止内存无限增长
+3. **onDeactivated中清理资源** — 定时器、事件监听器必须暂停
+4. **onActivated中刷新数据** — 根据时间戳或标记智能刷新
+5. **组件name和路由name保持一致** — 否则缓存不生效
+6. **Transition在外，KeepAlive在内** — 嵌套顺序别搞反
+
+| 场景        | 建议                            |
+| ----------- | ------------------------------- |
+| 列表页      | 缓存，onActivated智能刷新       |
+| 详情页      | 不缓存，每次重新加载            |
+| 表单页      | 缓存，防止误切丢失              |
+| 实时数据页  | 不缓存，或缓存+每次激活强制刷新 |
+| 设置页      | 缓存，不需要频繁刷新            |
+| 支付/敏感页 | 绝对不缓存                      |
+
+## 课后Quiz
+
+### 问题1：缓存组件中的setInterval在组件被deactivated后还会继续执行吗？
+
+**答案解析：** 会的！setInterval是浏览器API，跟Vue的生命周期没有关系。组件被deactivated只是从DOM上移除了，但定时器还在后台跑着。所以必须在onDeactivated中手动clearInterval，否则会造成内存泄漏和性能问题。
+
+### 问题2：KeepAlive和Transition嵌套时，谁应该在外层？
+
+**答案解析：** Transition应该在外层，KeepAlive应该在内层。因为Transition需要监听子组件的挂载/卸载来触发过渡动画，如果KeepAlive在外面，组件切走时不会被卸载（只是deactivated），Transition就感知不到变化，动画不会生效。
+
+## 常见报错解决方案
+
+### 1. 缓存页面内存持续增长
+
+**错误现象：** 随着使用时间增长，页面越来越卡，Chrome DevTools显示内存占用持续上升。
+
+**可能原因：** 缓存组件中的定时器、事件监听器、大数组没有在onDeactivated中清理。
+
+**解决方案：** 在每个缓存组件的onDeactivated中检查并清理：clearInterval/clearTimeout、removeEventListener、释放大数组引用。在onActivated中按需恢复。
+
+### 2. 缓存页面数据不更新
+
+**错误现象：** 从其他页面返回缓存页面，看到的是旧数据。
+
+**可能原因：** 缓存组件的数据不会自动更新，onActivated中没有刷新逻辑。
+
+**解决方案：** 在onActivated中添加数据刷新逻辑，可以用时间戳判断数据是否过期，或者用路由query参数标记需要强制刷新。
+
+### 3. Transition动画不生效
+
+**错误现象：** KeepAlive包裹的组件切换时没有过渡动画。
+
+**可能原因：** KeepAlive和Transition嵌套顺序错误，KeepAlive在外层导致Transition感知不到组件变化。
+
+**解决方案：** 调整嵌套顺序，Transition在外，KeepAlive在内。
+
+参考链接：
+
+- https://cn.vuejs.org/guide/built-ins/keep-alive.html
+- https://cn.vuejs.org/guide/built-ins/transition.html
+
+余下文章内容请点击跳转至 个人博客页面 或者 扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`，阅读完整的文章：[KeepAlive踩坑指南——内存泄漏、数据陈旧和不该用的场景](https://blog.cmdragon.cn/posts/k6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1/)
+
+<details>
+<summary>往期文章归档</summary>
+
+- [Vue 3 静态与动态 Props 如何传递？TypeScript 类型约束有何必要？](https://blog.cmdragon.cn/posts/94ab48753b64780ca3ab7a7115ae8522/)
+- [Vue 3中组件局部注册的优势与实现方式如何？](https://blog.cmdragon.cn/posts/dbf576e744870f6de26fd8a2e03e47da/)
+- [如何在Vue3中优化生命周期钩子性能并规避常见陷阱？](https://blog.cmdragon.cn/posts/12d98b3b9ccd6c19a1b169d720ac5c80/)
+- [Vue 3 Composition API生命周期钩子：如何实现从基础理解到高阶复用？](https://blog.cmdragon.cn/posts/8884e2b70287fcb263c57648eeb27419/)
+- [Vue 3生命周期钩子实战指南：如何正确选择onMounted、onUpdated与onUnmounted的应用场景？](https://blog.cmdragon.cn/posts/883c6dbc50ae4183770a4462e0b8ae4d/)
+
+</details>
+
+<details>
+<summary>免费好用的热门在线工具</summary>
+
+- [多直播聚合器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/multi-live-aggregator)
+- [Proto文件生成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/proto-file-generator)
+- [图片转粒子 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/image-to-particles)
+- [视频下载器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/video-downloader)
+- [文件格式转换器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/file-converter)
+- [M3U8在线播放器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/m3u8-player)
+- [CMDragon 在线工具 - 高级AI工具箱与开发者套件 | 免费好用的在线工具](https://tools.cmdragon.cn/zh)
+- [应用商店 - 发现1000+提升效率与开发的AI工具和实用程序 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps?category=trending)
+
+</details>

--- a/content/posts/front_end/vue/不是所有组件都值得缓存——include和exclude怎么挑.md
+++ b/content/posts/front_end/vue/不是所有组件都值得缓存——include和exclude怎么挑.md
@@ -1,0 +1,282 @@
+---
+url: /posts/k2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7/
+title: 不是所有组件都值得缓存——include和exclude怎么挑
+date: 2026-05-19T14:30:00+08:00
+lastmod: 2026-05-19T14:30:00+08:00
+author: cmdragon
+cover: https://api2.cmdragon.cn/upload/cmder/images/2026年6月7日 22_14_20.png
+
+summary: KeepAlive默认会把所有子组件都缓存，但有些组件缓存了反而占内存。include和exclude让你精准控制谁该缓存谁不该缓存，支持字符串、正则、数组三种写法，关键是组件的name要对得上。
+
+categories:
+  - vue
+
+tags:
+  - 基础入门
+  - KeepAlive
+  - include
+  - exclude
+  - 组件name
+  - 缓存过滤
+---
+
+<img src="https://api2.cmdragon.cn/upload/cmder/images/2026年6月7日 22_14_20.png" title="cover.png" alt="cmdragon_cn.png"/>
+
+<img src="https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg" title="cmdragon_cn.png" alt="cmdragon_cn.png"/>
+
+扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`
+
+[发现1000+提升效率与开发的AI工具和实用程序](https://tools.cmdragon.cn/zh/apps?category=ai_chat)：https://tools.cmdragon.cn/
+
+## 一、默认全缓存？那可不行
+
+上一篇咱学会了用KeepAlive缓存组件，确实好使。但KeepAlive有个默认行为——**它会把里面所有的子组件都缓存起来**。
+
+听起来好像没啥问题？但你想想，你家冰箱啥都往里塞，迟早得满，而且有些东西放冰箱反而坏了。
+
+比如你的应用里有10个动态组件，但只有2个需要缓存状态（一个搜索页、一个表单页），其他8个都是展示型页面，每次打开都应该拿最新数据。如果全缓存了，那8个组件白白占着内存，切回来还给你展示过期的数据，这不是给自己挖坑嘛。
+
+所以Vue给KeepAlive配了两个prop：**include** 和 **exclude**，让你精准控制谁该缓存、谁不该缓存。
+
+```mermaid
+flowchart TD
+    A[组件被切走] --> B{KeepAlive有include/exclude吗?}
+    B -->|没有| C[默认缓存所有组件]
+    B -->|有include| D{组件name在include里?}
+    B -->|有exclude| E{组件name在exclude里?}
+    D -->|是| F[缓存]
+    D -->|否| G[不缓存,销毁]
+    E -->|是| G
+    E -->|否| F
+```
+
+## 二、include：白名单模式，只缓存指定的
+
+include就是"白名单"——只有名单上的组件才会被缓存，其他的一律不缓存。
+
+它支持三种写法：
+
+### 写法1：逗号分隔字符串
+
+最简单的写法，直接写组件名，用英文逗号隔开：
+
+```vue
+<KeepAlive include="CompA,CompB">
+  <component :is="current" />
+</KeepAlive>
+```
+
+注意：这种写法**不需要**加 `v-bind`（也就是不用加冒号），因为include接收的就是字符串。
+
+### 写法2：正则表达式
+
+用正则来匹配组件名，更灵活：
+
+```vue
+<!-- 需要加v-bind（冒号） -->
+<KeepAlive :include="/CompA|CompB/">
+  <component :is="current" />
+</KeepAlive>
+```
+
+正则写法的好处是你可以用模式匹配，比如 `/^List/` 可以匹配所有以"List"开头的组件名。
+
+**注意：** 正则写法必须加 `v-bind`（冒号），否则Vue会把 `/CompA|CompB/` 当成普通字符串。
+
+### 写法3：数组
+
+最清晰的写法，把组件名放在数组里：
+
+```vue
+<!-- 需要加v-bind（冒号） -->
+<KeepAlive :include="['CompA', 'CompB']">
+  <component :is="current" />
+</KeepAlive>
+```
+
+数组写法也必须加 `v-bind`，因为你要传的是数组而不是字符串。
+
+三种写法效果一样，选哪种看你喜好。我个人推荐数组写法，一目了然，不容易写错。
+
+## 三、exclude：黑名单模式，不缓存指定的
+
+exclude和include刚好反过来——名单上的组件**不**缓存，其他都缓存。
+
+三种写法跟include一模一样：
+
+```vue
+<!-- 逗号字符串 -->
+<KeepAlive exclude="CompC,CompD">
+  <component :is="current" />
+</KeepAlive>
+
+<!-- 正则 -->
+<KeepAlive :exclude="/CompC|CompD/">
+  <component :is="current" />
+</KeepAlive>
+
+<!-- 数组 -->
+<KeepAlive :exclude="['CompC', 'CompD']">
+  <component :is="current" />
+</KeepAlive>
+```
+
+### 什么时候用include，什么时候用exclude？
+
+简单说就是看哪个写起来更短：
+
+- **需要缓存的少** → 用include白名单（只列几个要缓存的）
+- **不需要缓存的多** → 用exclude黑名单（只列几个不缓存的）
+
+举个例子：你有10个组件，8个要缓存2个不要 → 用exclude只写2个名字。反过来2个要缓存8个不要 → 用include只写2个名字。
+
+别同时用include和exclude，虽然Vue不会报错，但逻辑上容易混乱，维护起来也费劲。
+
+## 四、组件name：匹配的关键
+
+这是很多人踩坑的地方——include和exclude是根据**组件的name选项**来匹配的，不是根据变量名、文件名或者路由名。
+
+如果你的组件没有声明name，那include/exclude就认不出它，等于白配。
+
+### 选项式API中声明name
+
+```javascript
+export default {
+  name: "CompA", // 这个name就是include匹配的依据
+  data() {
+    return { count: 0 };
+  },
+};
+```
+
+### script setup中的name
+
+在Vue 3.2.34及以上版本，使用 `<script setup>` 的单文件组件会**自动根据文件名生成name**。比如你的文件叫 `CompA.vue`，那name自动就是 `CompA`。
+
+但如果你文件名和想要匹配的name不一致呢？比如文件叫 `UserListPage.vue`，但你想在include里用 `UserList` 来匹配。这时候有两种办法：
+
+**方法1：用defineOptions（Vue 3.3+）**
+
+```vue
+<script setup>
+defineOptions({
+  name: "UserList",
+});
+
+const searchQuery = ref("");
+</script>
+```
+
+**方法2：加一个普通的script块**
+
+```vue
+<script>
+export default {
+  name: "UserList",
+};
+</script>
+
+<script setup>
+const searchQuery = ref("");
+</script>
+```
+
+咱就是说，name对不上，include就认不出你，等于白配。所以一定要确保include/exclude里写的名字和组件的name一致。
+
+## 五、动态include/exclude
+
+include和exclude的值可以是响应式的！这意味着你可以根据运行时条件动态决定缓存哪些组件。
+
+比如根据用户角色来决定：
+
+```vue
+<script setup>
+import { computed } from "vue";
+import { useUserStore } from "./stores/user";
+
+const userStore = useUserStore();
+
+// 管理员缓存更多组件，普通用户只缓存基础组件
+const cachedComponents = computed(() => {
+  if (userStore.role === "admin") {
+    return ["Dashboard", "UserList", "Settings", "Reports"];
+  }
+  return ["Dashboard", "Settings"];
+});
+</script>
+
+<template>
+  <KeepAlive :include="cachedComponents">
+    <component :is="currentComponent" />
+  </KeepAlive>
+</template>
+```
+
+或者配合Vue Router的meta信息动态生成include列表（这个下一篇会详细讲）。
+
+## 课后Quiz
+
+### 问题1：include="CompA,CompB"和:include="['CompA','CompB']"有什么区别？
+
+**答案解析：** 效果一样，但语法不同。`include="CompA,CompB"` 是直接传字符串，Vue内部会按逗号分隔解析。`:include="['CompA','CompB']"` 是通过v-bind传数组。字符串写法不需要冒号，数组和正则写法必须加冒号。
+
+### 问题2：为什么script setup中的组件有时候不需要手动声明name？
+
+**答案解析：** 在Vue 3.2.34及以上版本，使用 `<script setup>` 的单文件组件会自动根据文件名生成name选项。比如 `CompA.vue` 会自动生成name为 `CompA`。所以只要include里写的名字和文件名一致，就不需要手动声明。但如果文件名和匹配名不一致，就需要用defineOptions或额外的script块手动声明。
+
+## 常见报错解决方案
+
+### 1. include/exclude不生效
+
+**错误现象：** 配了include但组件还是被缓存了，或者配了exclude但组件还是被缓存。
+
+**可能原因：** 组件的name和include/exclude里写的不一致。这是最常见的原因。
+
+**解决方案：** 打开浏览器DevTools，在Vue DevTools里查看组件的实际name，确保和include/exclude里写的一致。特别注意大小写！
+
+### 2. 正则表达式写法报错
+
+**错误现象：** 使用正则写法后，缓存控制不生效。
+
+**可能原因：** 忘记加v-bind（冒号）。`include="/CompA|CompB/"` 会把正则当成普通字符串。
+
+**解决方案：** 改成 `:include="/CompA|CompB/"`，加上冒号。
+
+### 3. script setup组件name不匹配
+
+**错误现象：** 文件名是 `UserListPage.vue`，include里写的是 `UserList`，结果不生效。
+
+**可能原因：** 自动生成的name是 `UserListPage`，和include里的 `UserList` 不一致。
+
+**解决方案：** 用 `defineOptions({ name: 'UserList' })` 手动声明name，或者把include改成 `UserListPage`。
+
+参考链接：
+
+- https://cn.vuejs.org/guide/built-ins/keep-alive.html
+
+余下文章内容请点击跳转至 个人博客页面 或者 扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`，阅读完整的文章：[不是所有组件都值得缓存——include和exclude怎么挑](https://blog.cmdragon.cn/posts/k2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7/)
+
+<details>
+<summary>往期文章归档</summary>
+
+- [Vue 3 静态与动态 Props 如何传递？TypeScript 类型约束有何必要？](https://blog.cmdragon.cn/posts/94ab48753b64780ca3ab7a7115ae8522/)
+- [Vue 3中组件局部注册的优势与实现方式如何？](https://blog.cmdragon.cn/posts/dbf576e744870f6de26fd8a2e03e47da/)
+- [如何在Vue3中优化生命周期钩子性能并规避常见陷阱？](https://blog.cmdragon.cn/posts/12d98b3b9ccd6c19a1b169d720ac5c80/)
+- [Vue 3 Composition API生命周期钩子：如何实现从基础理解到高阶复用？](https://blog.cmdragon.cn/posts/8884e2b70287fcb263c57648eeb27419/)
+- [Vue 3生命周期钩子实战指南：如何正确选择onMounted、onUpdated与onUnmounted的应用场景？](https://blog.cmdragon.cn/posts/883c6dbc50ae4183770a4462e0b8ae4d/)
+
+</details>
+
+<details>
+<summary>免费好用的热门在线工具</summary>
+
+- [多直播聚合器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/multi-live-aggregator)
+- [Proto文件生成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/proto-file-generator)
+- [图片转粒子 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/image-to-particles)
+- [视频下载器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/video-downloader)
+- [文件格式转换器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/file-converter)
+- [M3U8在线播放器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/m3u8-player)
+- [CMDragon 在线工具 - 高级AI工具箱与开发者套件 | 免费好用的在线工具](https://tools.cmdragon.cn/zh)
+- [应用商店 - 发现1000+提升效率与开发的AI工具和实用程序 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps?category=trending)
+
+</details>

--- a/content/posts/front_end/vue/组件切来切去状态全丢了？KeepAlive帮你保住.md
+++ b/content/posts/front_end/vue/组件切来切去状态全丢了？KeepAlive帮你保住.md
@@ -1,0 +1,262 @@
+---
+url: /posts/k1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6/
+title: 组件切来切去状态全丢了？KeepAlive帮你保住
+date: 2026-05-19T14:00:00+08:00
+lastmod: 2026-05-19T14:00:00+08:00
+author: cmdragon
+cover: https://api2.cmdragon.cn/upload/cmder/images/2026年6月7日 21_54_21.png
+
+summary: 动态组件切换时状态总是被重置？计数器归零、输入框清空、滚动位置丢失……KeepAlive就是Vue 3给你准备的"保鲜膜"，把切走的组件状态牢牢锁住，切回来还是原来的样子。
+
+categories:
+  - vue
+
+tags:
+  - 基础入门
+  - KeepAlive
+  - 动态组件
+  - 组件缓存
+  - 状态保持
+  - 内置组件
+---
+
+<img src="https://api2.cmdragon.cn/upload/cmder/images/2026年6月7日 21_54_21.png" title="cover.png" alt="cmdragon_cn.png"/>
+
+<img src="https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg" title="cmdragon_cn.png" alt="cmdragon_cn.png"/>
+
+扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`
+
+[发现1000+提升效率与开发的AI工具和实用程序](https://tools.cmdragon.cn/zh/apps?category=ai_chat)：https://tools.cmdragon.cn/
+
+## 一、动态组件切换的"失忆症"
+
+在Vue 3里，动态组件是个特别方便的东西，你可以用 `<component :is="xxx">` 来根据条件切换不同的组件，就像翻牌子一样——想看谁就翻谁的牌。
+
+```vue
+<script setup>
+import { ref } from "vue";
+import CompA from "./CompA.vue";
+import CompB from "./CompB.vue";
+
+const current = ref("CompA");
+</script>
+
+<template>
+  <button @click="current = 'CompA'">显示A</button>
+  <button @click="current = 'CompB'">显示B</button>
+
+  <component :is="current === 'CompA' ? CompA : CompB" />
+</template>
+```
+
+但是呢，这个动态组件有个让人头疼的毛病——**切换就失忆**。
+
+你辛辛苦苦填了一堆表单，点了个标签页切走，再切回来一看——白屏了，啥都没了，心态崩不崩？
+
+来，咱看个具体的例子。组件A里有个计数器，组件B里有个输入框：
+
+```vue
+<!-- CompA.vue -->
+<script setup>
+import { ref } from "vue";
+
+const count = ref(0);
+</script>
+
+<template>
+  <div style="padding: 20px; border: 2px solid #42b983;">
+    <h3>组件A - 计数器</h3>
+    <p>当前计数：{{ count }}</p>
+    <button @click="count++">点我+1</button>
+  </div>
+</template>
+```
+
+```vue
+<!-- CompB.vue -->
+<script setup>
+import { ref } from "vue";
+
+const text = ref("");
+</script>
+
+<template>
+  <div style="padding: 20px; border: 2px solid #ff6b6b;">
+    <h3>组件B - 输入框</h3>
+    <input v-model="text" placeholder="随便写点啥" />
+    <p>你输入了：{{ text }}</p>
+  </div>
+</template>
+```
+
+现在你在组件A里点了5下计数器，切到组件B输入了"你好"，再切回A——计数器归零了！切到B——输入框也空了！
+
+这就是默认行为：**组件被替换掉后会被销毁，所有状态跟着一起灰飞烟灭**。下次再显示的时候，Vue会创建一个全新的实例，只有初始状态，之前的操作痕迹全没了。
+
+## 二、KeepAlive：给组件贴上"保鲜膜"
+
+Vue 3早就料到你会遇到这个问题，所以给你准备了一个内置组件——`<KeepAlive>`。
+
+用法简单到离谱，就一步：**把动态组件用KeepAlive包起来**。
+
+```vue
+<script setup>
+import { ref } from "vue";
+import CompA from "./CompA.vue";
+import CompB from "./CompB.vue";
+
+const current = ref("CompA");
+</script>
+
+<template>
+  <button @click="current = 'CompA'">显示A</button>
+  <button @click="current = 'CompB'">显示B</button>
+
+  <!-- 不加KeepAlive：切换后状态丢失 -->
+  <!-- <component :is="current === 'CompA' ? CompA : CompB" /> -->
+
+  <!-- 加了KeepAlive：切换后状态保留！ -->
+  <KeepAlive>
+    <component :is="current === 'CompA' ? CompA : CompB" />
+  </KeepAlive>
+</template>
+```
+
+加了KeepAlive之后，你在组件A里点了5下，切到B输入了"你好"，再切回A——计数器还是5！切到B——"你好"还在！
+
+就这么简单，一行代码搞定状态保持。
+
+## 三、KeepAlive到底做了啥？
+
+光知道怎么用还不够，咱得搞明白KeepAlive背后的原理，不然遇到坑都不知道咋回事。
+
+### 普通切换 vs KeepAlive切换
+
+不用KeepAlive的时候，组件切换的流程是这样的：
+
+```mermaid
+flowchart TD
+    A[显示组件A] --> B[切换到组件B]
+    B --> C[组件A触发 unmounted - 销毁]
+    C --> D[组件B触发 mounted - 创建]
+    D --> E[切换回组件A]
+    E --> F[组件B触发 unmounted - 销毁]
+    F --> G[组件A触发 mounted - 重新创建 - 状态归零!]
+```
+
+用了KeepAlive之后，流程变成了这样：
+
+```mermaid
+flowchart TD
+    A[显示组件A] --> B[切换到组件B]
+    B --> C[组件A触发 deactivated - 冬眠]
+    C --> D[组件B触发 mounted - 首次创建]
+    D --> E[切换回组件A]
+    E --> F[组件B触发 deactivated - 冬眠]
+    F --> G[组件A触发 activated - 唤醒 - 状态还在!]
+```
+
+看出区别了吧？
+
+| 对比项   | 不用KeepAlive       | 用KeepAlive         |
+| -------- | ------------------- | ------------------- |
+| 切走时   | unmounted（销毁）   | deactivated（冬眠） |
+| 切回时   | mounted（重新创建） | activated（唤醒）   |
+| 状态     | 全部丢失            | 完整保留            |
+| 组件实例 | 被销毁，内存释放    | 保留在内存中        |
+
+说白了，KeepAlive就是让被切走的组件"冬眠"而不是"死亡"。组件实例还活着，只是从DOM树上摘下来了，安安静静躺在内存里等你回来。等你切回来的时候，把它"唤醒"重新挂到DOM上，之前的状态一个不落全都在。
+
+这就好比你把吃了一半的零食放进保鲜盒（KeepAlive），而不是直接扔垃圾桶（unmounted）。下次打开保鲜盒，零食还是那个零食。
+
+## 四、DOM内模板的注意事项
+
+有个小细节提一嘴：如果你是在DOM内模板（就是直接写在HTML文件里的模板）中使用KeepAlive，要写成 `<keep-alive>` 而不是 `<KeepAlive>`。
+
+原因是HTML不区分大小写，驼峰命名的组件在DOM模板里会被浏览器自动转成小写，Vue就认不出来了。所以在DOM模板里要用短横线命名：
+
+```html
+<!-- DOM模板中要这样写 -->
+<keep-alive>
+  <component :is="currentView"></component>
+</keep-alive>
+```
+
+而在SFC（.vue文件）里，两种写法都行，但推荐用 `<KeepAlive>` 驼峰写法，因为这是Vue 3的官方风格。
+
+## 课后Quiz
+
+### 问题1：不使用KeepAlive时，动态组件切换后原组件会触发什么生命周期钩子？
+
+**答案解析：** 会触发 `unmounted` 钩子。组件被替换掉后会被完全销毁，触发unmounted，组件实例从内存中移除，所有状态丢失。下次再显示时会重新创建，触发mounted。
+
+### 问题2：KeepAlive包裹的组件被切走时，组件是被销毁还是被缓存？
+
+**答案解析：** 是被缓存，不是被销毁。组件会触发 `deactivated` 钩子进入"冬眠"状态，组件实例仍然保留在内存中。切回来时触发 `activated` 钩子被"唤醒"，之前的状态完整保留。
+
+## 常见报错解决方案
+
+### 1. KeepAlive不生效
+
+**错误现象：** 明明用了KeepAlive包裹组件，但切换后状态还是丢了。
+
+**可能原因：**
+
+- KeepAlive里面有多个直接子组件。KeepAlive只能包一个动态组件，如果有多个兄弟元素就不生效。
+- 动态组件的值不是组件对象或组件名字符串。
+
+**解决方案：**
+
+确保KeepAlive只有一个直接子组件，并且这个子组件是动态组件：
+
+```vue
+<!-- 错误：KeepAlive里有多个子元素 -->
+<KeepAlive>
+  <div>标题</div>
+  <component :is="current" />
+</KeepAlive>
+
+<!-- 正确：KeepAlive里只有一个动态组件 -->
+<KeepAlive>
+  <component :is="current" />
+</KeepAlive>
+```
+
+### 2. 组件切换报错"Component is not a valid element"
+
+**错误现象：** 切换组件时控制台报错。
+
+**可能原因：** 动态组件绑定的值不是已注册的组件。
+
+**解决方案：** 确保传入的组件已经正确导入和注册。在script setup中需要import组件，或者传入已全局注册的组件名字符串。
+
+参考链接：
+
+- https://cn.vuejs.org/guide/built-ins/keep-alive.html
+
+余下文章内容请点击跳转至 个人博客页面 或者 扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`，阅读完整的文章：[组件切来切去状态全丢了？KeepAlive帮你保住](https://blog.cmdragon.cn/posts/k1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6/)
+
+<details>
+<summary>往期文章归档</summary>
+
+- [Vue 3 静态与动态 Props 如何传递？TypeScript 类型约束有何必要？](https://blog.cmdragon.cn/posts/94ab48753b64780ca3ab7a7115ae8522/)
+- [Vue 3中组件局部注册的优势与实现方式如何？](https://blog.cmdragon.cn/posts/dbf576e744870f6de26fd8a2e03e47da/)
+- [如何在Vue3中优化生命周期钩子性能并规避常见陷阱？](https://blog.cmdragon.cn/posts/12d98b3b9ccd6c19a1b169d720ac5c80/)
+- [Vue 3 Composition API生命周期钩子：如何实现从基础理解到高阶复用？](https://blog.cmdragon.cn/posts/8884e2b70287fcb263c57648eeb27419/)
+- [Vue 3生命周期钩子实战指南：如何正确选择onMounted、onUpdated与onUnmounted的应用场景？](https://blog.cmdragon.cn/posts/883c6dbc50ae4183770a4462e0b8ae4d/)
+
+</details>
+
+<details>
+<summary>免费好用的热门在线工具</summary>
+
+- [多直播聚合器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/multi-live-aggregator)
+- [Proto文件生成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/proto-file-generator)
+- [图片转粒子 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/image-to-particles)
+- [视频下载器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/video-downloader)
+- [文件格式转换器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/file-converter)
+- [M3U8在线播放器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/m3u8-player)
+- [CMDragon 在线工具 - 高级AI工具箱与开发者套件 | 免费好用的在线工具](https://tools.cmdragon.cn/zh)
+- [应用商店 - 发现1000+提升效率与开发的AI工具和实用程序 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps?category=trending)
+
+</details>

--- a/content/posts/front_end/vue/缓存太多内存炸了？max属性和LRU淘汰策略来救场.md
+++ b/content/posts/front_end/vue/缓存太多内存炸了？max属性和LRU淘汰策略来救场.md
@@ -1,0 +1,199 @@
+---
+url: /posts/k3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8/
+title: 缓存太多内存炸了？max属性和LRU淘汰策略来救场
+date: 2026-05-19T15:00:00+08:00
+lastmod: 2026-05-19T15:00:00+08:00
+author: cmdragon
+cover: https://api2.cmdragon.cn/upload/cmder/images/2026年6月7日 22_20_31.png
+
+summary: KeepAlive缓存组件很爽，但缓存太多内存就遭不住了。max属性让你限制最大缓存数量，超出的按LRU策略淘汰最久没用的组件。这篇文章帮你搞明白LRU是啥、max怎么配、缓存淘汰时组件会发生什么。
+
+categories:
+  - vue
+
+tags:
+  - 基础入门
+  - KeepAlive
+  - max属性
+  - LRU缓存
+  - 内存管理
+  - 缓存淘汰
+---
+
+<img src="https://api2.cmdragon.cn/upload/cmder/images/2026年6月7日 22_20_31.png" title="cover.png" alt="cmdragon_cn.png"/>
+
+<img src="https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg" title="cmdragon_cn.png" alt="cmdragon_cn.png"/>
+
+扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`
+
+[发现1000+提升效率与开发的AI工具和实用程序](https://tools.cmdragon.cn/zh/apps?category=ai_chat)：https://tools.cmdragon.cn/
+
+## 一、缓存是好事，但别贪多
+
+前面咱学了KeepAlive的基本用法和include/exclude过滤，已经能精准控制哪些组件该缓存了。但还有一个问题——**缓存太多怎么办？**
+
+每个被缓存的组件实例都占着内存呢。组件越复杂、数据越多，占的内存就越大。你想想，一个列表页缓存了几百条数据，一个表单页缓存了一大堆表单状态，再来几个图表页……内存占用蹭蹭往上涨。
+
+在PC端可能还好，但在移动端或者低配设备上，内存一紧张页面就卡，严重的直接白屏闪退。
+
+缓存就像冰箱，塞满了就放不进去了，而且电费（内存）还贵。所以你得给冰箱设个容量上限。
+
+## 二、max属性：给缓存设个上限
+
+KeepAlive提供了一个 `max` prop，用来限制最多缓存多少个组件实例：
+
+```vue
+<KeepAlive :max="5">
+  <component :is="currentComponent" />
+</KeepAlive>
+```
+
+就这么简单，加个 `:max="5"` 就行，表示最多缓存5个组件实例。
+
+当缓存数量即将超过max时，KeepAlive会自动淘汰最久没有被访问的缓存实例，给新的腾地方。
+
+注意max需要加v-bind（冒号），因为你要传的是数字不是字符串。`max="5"` 传的是字符串"5"，`:max="5"` 传的才是数字5。
+
+## 三、LRU是啥？用生活例子讲明白
+
+KeepAlive用的淘汰策略叫 **LRU**，全称 Least Recently Used，翻译过来就是"最近最少使用"。
+
+听着挺唬人，其实道理特别简单——**谁最久没被碰过，谁先滚蛋**。
+
+打个比方：你的衣柜容量有限（max），新衣服进来就得淘汰旧衣服。你肯定先淘汰那些积灰最久没穿过的，对吧？这就是LRU。
+
+来，咱用流程图演示一下LRU是怎么工作的（假设max=3）：
+
+```mermaid
+flowchart TD
+    A[缓存: A B C] -->|访问A| B[A变成最近使用]
+    B --> C[缓存顺序: B C A]
+    C -->|新增D| D{缓存数量 > max?}
+    D -->|是,3个已满| E[淘汰最久没用的B]
+    E --> F[缓存: C A D]
+    F -->|访问C| G[C变成最近使用]
+    G --> H[缓存顺序: A D C]
+    H -->|新增E| I{缓存数量 > max?}
+    I -->|是| J[淘汰最久没用的A]
+    J --> K[缓存: D C E]
+```
+
+关键点来了：**访问顺序很重要**。同样是A、B、C三个组件被缓存，如果你最近访问过A，那A就不会被优先淘汰。只有最久没被访问的那个才会被淘汰。
+
+这就是LRU的精妙之处——它不是简单地"先进先出"，而是根据使用频率和最近使用时间来决定淘汰谁。
+
+## 四、被淘汰的组件会怎样？
+
+被LRU淘汰的组件会被**真正销毁**，触发 `unmounted` 钩子。不是冬眠，是真的没了。
+
+下次再显示这个组件时，会重新创建，触发 `mounted`，状态归零。
+
+来验证一下：
+
+```vue
+<!-- TestComponent.vue -->
+<script setup>
+import { onMounted, onUnmounted, onActivated, onDeactivated } from "vue";
+
+onMounted(() => console.log("🟢 mounted - 创建"));
+onUnmounted(() => console.log("🔴 unmounted - 销毁"));
+onActivated(() => console.log("⚡ activated - 激活"));
+onDeactivated(() => console.log("💤 deactivated - 冬眠"));
+</script>
+
+<template>
+  <div>测试组件</div>
+</template>
+```
+
+当这个组件被LRU淘汰时，控制台会打印 `🔴 unmounted - 销毁`，说明它是被真正销毁了，不是简单的隐藏。
+
+## 五、max配多少合适？
+
+这个问题没有标准答案，取决于几个因素：
+
+| 因素         | 建议                                 |
+| ------------ | ------------------------------------ |
+| 组件复杂度   | 复杂组件（大量数据/图表）→ max小一点 |
+| 目标设备     | 移动端/低配设备 → max 3-5            |
+| 用户切换频率 | 频繁切换多个页面 → max大一点         |
+| 内存限制     | 内存紧张 → max小一点                 |
+
+**一般建议：**
+
+- PC端：5-10
+- 移动端：3-5
+- 如果组件很轻量（纯展示型）：可以适当增大
+- 如果组件很重（大量数据/图表）：适当减小
+
+**更好的做法是max和include配合使用：**
+
+```vue
+<KeepAlive :include="['ListPage', 'SearchPage']" :max="5">
+  <component :is="currentComponent" />
+</KeepAlive>
+```
+
+先用include过滤出需要缓存的组件，再用max限制总数，双重保险。
+
+## 课后Quiz
+
+### 问题1：当缓存数量超过max时，哪个组件会被优先淘汰？
+
+**答案解析：** 最久没有被访问的组件会被优先淘汰。KeepAlive使用LRU（最近最少使用）策略，根据组件的最近访问时间来决定淘汰顺序，最久没被"碰"过的最先被淘汰。
+
+### 问题2：被LRU淘汰的组件，下次显示时状态还在吗？
+
+**答案解析：** 不在了。被淘汰的组件会被真正销毁（触发unmounted），不是冬眠。下次显示时会重新创建（触发mounted），状态会重置为初始值。
+
+## 常见报错解决方案
+
+### 1. max设太小导致频繁重建组件
+
+**错误现象：** 组件经常被淘汰重建，用户体验差，感觉缓存没起作用。
+
+**解决方案：** 适当增大max值，或者配合include只缓存真正需要的组件，这样有限的max名额都用在刀刃上。
+
+### 2. max设太大移动端卡顿
+
+**错误现象：** 移动端页面越来越卡，内存占用持续增长。
+
+**解决方案：** 移动端建议max设3-5，优先缓存轻量组件。重组件（大数据列表、图表）尽量不缓存，或者缓存时在onDeactivated中释放大数据。
+
+### 3. max和include同时使用时的优先级
+
+**疑问：** max和include谁先生效？
+
+**答案：** 先过滤再淘汰。include决定谁能进缓存（不在include里的直接不缓存），max决定缓存上限（超了就LRU淘汰）。两者是配合关系，不是覆盖关系。
+
+参考链接：
+
+- https://cn.vuejs.org/guide/built-ins/keep-alive.html
+- https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)
+
+余下文章内容请点击跳转至 个人博客页面 或者 扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`，阅读完整的文章：[缓存太多内存炸了？max属性和LRU淘汰策略来救场](https://blog.cmdragon.cn/posts/k3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8/)
+
+<details>
+<summary>往期文章归档</summary>
+
+- [Vue 3 静态与动态 Props 如何传递？TypeScript 类型约束有何必要？](https://blog.cmdragon.cn/posts/94ab48753b64780ca3ab7a7115ae8522/)
+- [Vue 3中组件局部注册的优势与实现方式如何？](https://blog.cmdragon.cn/posts/dbf576e744870f6de26fd8a2e03e47da/)
+- [如何在Vue3中优化生命周期钩子性能并规避常见陷阱？](https://blog.cmdragon.cn/posts/12d98b3b9ccd6c19a1b169d720ac5c80/)
+- [Vue 3 Composition API生命周期钩子：如何实现从基础理解到高阶复用？](https://blog.cmdragon.cn/posts/8884e2b70287fcb263c57648eeb27419/)
+- [Vue 3生命周期钩子实战指南：如何正确选择onMounted、onUpdated与onUnmounted的应用场景？](https://blog.cmdragon.cn/posts/883c6dbc50ae4183770a4462e0b8ae4d/)
+
+</details>
+
+<details>
+<summary>免费好用的热门在线工具</summary>
+
+- [多直播聚合器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/multi-live-aggregator)
+- [Proto文件生成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/proto-file-generator)
+- [图片转粒子 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/image-to-particles)
+- [视频下载器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/video-downloader)
+- [文件格式转换器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/file-converter)
+- [M3U8在线播放器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/m3u8-player)
+- [CMDragon 在线工具 - 高级AI工具箱与开发者套件 | 免费好用的在线工具](https://tools.cmdragon.cn/zh)
+- [应用商店 - 发现1000+提升效率与开发的AI工具和实用程序 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps?category=trending)
+
+</details>

--- a/content/posts/front_end/vue/被缓存的组件冬眠了吗？onActivated和onDeactivated告诉你答案.md
+++ b/content/posts/front_end/vue/被缓存的组件冬眠了吗？onActivated和onDeactivated告诉你答案.md
@@ -1,0 +1,381 @@
+---
+url: /posts/k4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9/
+title: 被缓存的组件"死"了吗？onActivated和onDeactivated告诉你答案
+date: 2026-05-19T15:30:00+08:00
+lastmod: 2026-05-19T15:30:00+08:00
+author: cmdragon
+cover: https://api2.cmdragon.cn/upload/cmder/images/2026年6月7日 22_30_17.png
+
+summary: KeepAlive缓存的组件既不是活着也不是死了，而是"冬眠"了。onActivated在组件被激活时叫醒它，onDeactivated在组件进入缓存时让它休眠。搞懂这两个钩子和mounted/unmounted的区别，你才能真正驾驭缓存组件。
+
+categories:
+  - vue
+
+tags:
+  - 基础入门
+  - KeepAlive
+  - onActivated
+  - onDeactivated
+  - 缓存生命周期
+  - 组件激活
+---
+
+<img src="https://api2.cmdragon.cn/upload/cmder/images/2026年6月7日 22_30_17.png" title="cover.png" alt="cmdragon_cn.png"/>
+
+<img src="https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg" title="cmdragon_cn.png" alt="cmdragon_cn.png"/>
+
+扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`
+
+[发现1000+提升效率与开发的AI工具和实用程序](https://tools.cmdragon.cn/zh/apps?category=ai_chat)：https://tools.cmdragon.cn/
+
+## 一、缓存组件的"生死"状态
+
+前面咱说了，KeepAlive让被切走的组件"冬眠"而不是"死亡"。那冬眠的组件到底是个啥状态？它既不是活着（在DOM上），也不是死了（被销毁），而是介于两者之间——**不活跃状态**。
+
+普通组件的一生很简单：创建→挂载→更新→卸载，一锤子买卖。
+
+但缓存组件的一生就丰富多了：创建→挂载→**激活→停用→激活→停用→……**→卸载。这个"激活/停用"的循环就是KeepAlive带来的新状态。
+
+组件冬眠了，不是挂了，别急着烧纸。它还在内存里躺着呢，随时等你叫醒。
+
+## 二、onActivated：组件被叫醒时干啥
+
+`onActivated` 是Vue 3提供的组合式API钩子，在组件被激活时触发。
+
+**触发时机：**
+
+- 首次挂载时（和onMounted一起触发）
+- 每次从缓存中被重新插入DOM时
+
+**常见用途：**
+
+1. **刷新数据** — 列表页切回来时，可能需要获取最新数据
+2. **恢复定时器** — 之前暂停的定时器重新启动
+3. **恢复动画** — 之前暂停的动画继续播放
+4. **恢复滚动位置** — 切走时保存的位置，切回来时恢复
+
+```vue
+<script setup>
+import { onActivated, ref } from "vue";
+
+const dataList = ref([]);
+const lastRefreshTime = ref("");
+
+onActivated(() => {
+  console.log("组件被激活了！");
+  // 每次激活时刷新数据
+  fetchData();
+});
+
+async function fetchData() {
+  // 模拟API请求
+  const res = await fetch("/api/list");
+  dataList.value = await res.json();
+  lastRefreshTime.value = new Date().toLocaleString();
+}
+</script>
+```
+
+注意：首次挂载时，`onActivated` 在 `onMounted` **之后**触发。也就是说执行顺序是：`mounted → activated`。
+
+## 三、onDeactivated：组件去冬眠时干啥
+
+`onDeactivated` 也是Vue 3的组合式API钩子，在组件被停用（进入缓存）时触发。
+
+**触发时机：**
+
+- 从DOM移除、进入缓存时
+- 组件卸载时（也会触发！）
+
+**常见用途：**
+
+1. **暂停定时器** — 不清除，等激活时恢复
+2. **暂停动画** — 节省性能
+3. **保存当前状态** — 滚动位置、筛选条件等
+
+```vue
+<script setup>
+import { onDeactivated, ref } from "vue";
+
+const scrollTop = ref(0);
+let timer = null;
+
+onDeactivated(() => {
+  console.log("组件去冬眠了~");
+  // 保存滚动位置
+  scrollTop.value = document.querySelector(".list-container")?.scrollTop || 0;
+  // 暂停定时器（不是清除！）
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+});
+</script>
+```
+
+**重要提醒：** 组件卸载时 `onDeactivated` 也会触发。所以如果你在 `onDeactivated` 中做清理操作，要考虑组件是真的要卸载了还是只是去冬眠。
+
+## 四、和mounted/unmounted的区别
+
+这是很多人搞混的地方，咱用表格和时序图彻底搞明白：
+
+| 特性           | mounted/unmounted | onActivated/onDeactivated |
+| -------------- | ----------------- | ------------------------- |
+| 触发次数       | 各只触发1次       | 可多次触发                |
+| 缓存组件切走时 | 不触发unmounted   | 触发onDeactivated         |
+| 缓存组件切回时 | 不触发mounted     | 触发onActivated           |
+| 首次挂载时     | mounted触发       | onActivated也触发         |
+| 组件卸载时     | unmounted触发     | onDeactivated也触发       |
+
+完整的触发时序：
+
+```mermaid
+sequenceDiagram
+    participant Vue
+    participant Component
+
+    Note over Vue,Component: 首次挂载
+    Vue->>Component: mounted
+    Vue->>Component: onActivated
+
+    Note over Vue,Component: 切走（缓存）
+    Vue->>Component: onDeactivated
+
+    Note over Vue,Component: 切回（激活）
+    Vue->>Component: onActivated
+
+    Note over Vue,Component: 再次切走
+    Vue->>Component: onDeactivated
+
+    Note over Vue,Component: 再次切回
+    Vue->>Component: onActivated
+
+    Note over Vue,Component: 组件被销毁（如超出max）
+    Vue->>Component: onDeactivated
+    Vue->>Component: unmounted
+```
+
+**核心区别：** mounted/unmounted是"生与死"，onActivated/onDeactivated是"醒与睡"。缓存组件只会"睡"和"醒"，不会反复"死"和"生"。
+
+## 五、选项式API的写法
+
+如果你用的是选项式API，对应的是 `activated` 和 `deactivated` 选项：
+
+```javascript
+export default {
+  name: "ListPage",
+
+  mounted() {
+    console.log("mounted - 组件创建");
+  },
+
+  activated() {
+    console.log("activated - 组件被激活");
+    // 刷新数据
+    this.fetchData();
+  },
+
+  deactivated() {
+    console.log("deactivated - 组件去冬眠");
+    // 保存状态
+    this.saveScrollPosition();
+  },
+
+  unmounted() {
+    console.log("unmounted - 组件销毁");
+  },
+};
+```
+
+两种写法效果一样，选你习惯的就行。
+
+## 六、后代组件也能感知到
+
+这是个容易被忽略的点——`onActivated` 和 `onDeactivated` 不仅适用于KeepAlive缓存的根组件，**也适用于缓存树中的后代组件**。
+
+什么意思呢？比如你的结构是这样的：
+
+```
+KeepAlive
+  └── ListPage（根组件，被缓存）
+        ├── SearchBar（子组件）
+        └── DataTable（子组件）
+```
+
+当ListPage被deactivated时，SearchBar和DataTable的 `onDeactivated` 也会触发。当ListPage被activated时，子组件们的 `onActivated` 也会触发。
+
+这很合理——爹冬眠了，孩子也跟着睡；爹醒了，孩子也跟着醒。
+
+```vue
+<!-- SearchBar.vue -->
+<script setup>
+import { onActivated, onDeactivated } from "vue";
+
+onActivated(() => {
+  console.log("SearchBar也被激活了");
+});
+
+onDeactivated(() => {
+  console.log("SearchBar也去冬眠了");
+});
+</script>
+```
+
+## 七、实战：列表页缓存与数据刷新
+
+来个完整的实战案例，把前面学的都用上：
+
+```vue
+<!-- ListPage.vue -->
+<script setup>
+import { ref, onMounted, onActivated, onDeactivated } from "vue";
+
+const list = ref([]);
+const loading = ref(false);
+const scrollTop = ref(0);
+const searchQuery = ref("");
+const lastFetchTime = ref(null);
+const listRef = ref(null);
+
+// 获取数据
+async function fetchData(force = false) {
+  // 如果不是强制刷新，且数据不超过30秒，就不重新获取
+  if (!force && lastFetchTime.value) {
+    const elapsed = Date.now() - lastFetchTime.value;
+    if (elapsed < 30000) {
+      console.log("数据还新鲜，不刷新");
+      return;
+    }
+  }
+
+  loading.value = true;
+  try {
+    const res = await fetch(`/api/list?q=${searchQuery.value}`);
+    list.value = await res.json();
+    lastFetchTime.value = Date.now();
+  } finally {
+    loading.value = false;
+  }
+}
+
+// 首次挂载获取数据
+onMounted(() => {
+  fetchData(true);
+});
+
+// 每次激活时判断是否需要刷新
+onActivated(() => {
+  // 恢复滚动位置
+  if (listRef.value && scrollTop.value) {
+    listRef.value.scrollTop = scrollTop.value;
+  }
+  // 智能刷新：超过30秒才重新获取
+  fetchData();
+});
+
+// 停用时保存状态
+onDeactivated(() => {
+  // 保存滚动位置
+  if (listRef.value) {
+    scrollTop.value = listRef.value.scrollTop;
+  }
+});
+</script>
+
+<template>
+  <div>
+    <input
+      v-model="searchQuery"
+      placeholder="搜索..."
+      @keyup.enter="fetchData(true)"
+    />
+    <div
+      ref="listRef"
+      class="list-container"
+      style="height: 500px; overflow-y: auto;"
+    >
+      <div v-if="loading">加载中...</div>
+      <div v-else>
+        <div v-for="item in list" :key="item.id" class="list-item">
+          {{ item.name }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+这个例子实现了：
+
+- 首次挂载获取数据
+- 切回来时智能判断是否需要刷新（30秒内不刷新）
+- 切走时保存滚动位置
+- 切回来时恢复滚动位置
+
+## 课后Quiz
+
+### 问题1：缓存组件首次挂载时，onActivated和onMounted的触发顺序是什么？
+
+**答案解析：** 先触发 `onMounted`，再触发 `onActivated`。首次挂载时两个钩子都会触发，顺序是 mounted → activated。这是因为组件先完成挂载（mounted），然后被KeepAlive标记为活跃状态（activated）。
+
+### 问题2：组件被KeepAlive缓存后切走时，unmounted会触发吗？
+
+**答案解析：** 不会。被KeepAlive缓存的组件切走时只触发 `onDeactivated`，不触发 `unmounted`。因为组件没有被销毁，只是进入了不活跃状态（冬眠）。只有当组件被真正销毁时（比如超出max被LRU淘汰，或者KeepAlive本身被卸载），才会触发 `unmounted`。
+
+## 常见报错解决方案
+
+### 1. onActivated不触发
+
+**错误现象：** 在组件里写了onActivated，但切换时没反应。
+
+**可能原因：** 组件没有被KeepAlive包裹，或者被exclude排除了。
+
+**解决方案：** 检查组件是否在KeepAlive内部，且没有被exclude排除。可以在组件里同时写onMounted和onActivated，打印日志确认哪个触发了。
+
+### 2. onActivated中刷新数据导致闪烁
+
+**错误现象：** 每次切回来页面都闪一下，因为数据重新加载了。
+
+**可能原因：** 在onActivated中无条件刷新数据，即使数据还是新的。
+
+**解决方案：** 添加判断条件，不是每次激活都刷新。可以用时间戳判断数据是否过期，或者用一个标记位记录是否需要刷新。
+
+### 3. 定时器在onDeactivated中clearInterval导致onActivated中无法恢复
+
+**错误现象：** 定时器被清除后，onActivated中无法恢复。
+
+**可能原因：** 在onDeactivated中用clearInterval清除了定时器，但onActivated中没有重新创建。
+
+**解决方案：** onDeactivated中应该"暂停"而不是"清除"定时器。或者在onActivated中重新创建定时器。具体选择取决于你的业务需求——如果定时器任务可以中断，就清除+重建；如果需要连续执行，就暂停+恢复。
+
+参考链接：
+
+- https://cn.vuejs.org/guide/built-ins/keep-alive.html
+- https://cn.vuejs.org/api/composition-api-lifecycle.html#onactivated
+
+余下文章内容请点击跳转至 个人博客页面 或者 扫描[二维码](https://api2.cmdragon.cn/upload/cmder/20250304_012821924.jpg)关注或者微信搜一搜：`编程智域 前端至全栈交流与成长`，阅读完整的文章：[被缓存的组件"死"了吗？onActivated和onDeactivated告诉你答案](https://blog.cmdragon.cn/posts/k4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9/)
+
+<details>
+<summary>往期文章归档</summary>
+
+- [Vue 3 静态与动态 Props 如何传递？TypeScript 类型约束有何必要？](https://blog.cmdragon.cn/posts/94ab48753b64780ca3ab7a7115ae8522/)
+- [Vue 3中组件局部注册的优势与实现方式如何？](https://blog.cmdragon.cn/posts/dbf576e744870f6de26fd8a2e03e47da/)
+- [如何在Vue3中优化生命周期钩子性能并规避常见陷阱？](https://blog.cmdragon.cn/posts/12d98b3b9ccd6c19a1b169d720ac5c80/)
+- [Vue 3 Composition API生命周期钩子：如何实现从基础理解到高阶复用？](https://blog.cmdragon.cn/posts/8884e2b70287fcb263c57648eeb27419/)
+- [Vue 3生命周期钩子实战指南：如何正确选择onMounted、onUpdated与onUnmounted的应用场景？](https://blog.cmdragon.cn/posts/883c6dbc50ae4183770a4462e0b8ae4d/)
+
+</details>
+
+<details>
+<summary>免费好用的热门在线工具</summary>
+
+- [多直播聚合器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/multi-live-aggregator)
+- [Proto文件生成器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/proto-file-generator)
+- [图片转粒子 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/image-to-particles)
+- [视频下载器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/video-downloader)
+- [文件格式转换器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/file-converter)
+- [M3U8在线播放器 - 应用商店 | By cmdragon](https://tools.cmdragon.cn/zh/apps/m3u8-player)
+- [CMDragon 在线工具 - 高级AI工具箱与开发者套件 | 免费好用的在线工具](https://tools.cmdragon.cn/zh)
+- [应用商店 - 发现1000+提升效率与开发的AI工具和实用程序 | 免费好用的在线工具](https://tools.cmdragon.cn/zh/apps?category=trending)
+
+</details>


### PR DESCRIPTION
新增从基础使用到进阶踩坑的完整KeepAlive教程，覆盖动态组件、路由缓存、缓存策略、生命周期钩子及最佳实践等内容